### PR TITLE
WIP: Remove expired online apps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV UNICORN_PORT 3000
 # runit needs inittab
 RUN touch /etc/inittab
 
-RUN apt-get update && apt-get install -y
+RUN apt-get update && apt-get install -y cron
 
 EXPOSE $UNICORN_PORT
 

--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,8 @@ gem 'will_paginate'
 # Soft deletion
 gem "paranoia", "~> 2.0"
 
+gem 'whenever', require: false
+
 group :development do
   # speed up local development via livereload
   gem 'guard-livereload'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
       capybara (>= 2.3.0, < 2.8.0)
       json
     chartkick (2.0.0)
+    chronic (0.10.2)
     climate_control (0.0.3)
       activesupport (>= 3.0)
     codeclimate-test-reporter (0.6.0)
@@ -400,6 +401,8 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
+    whenever (0.9.4)
+      chronic (>= 0.6.3)
     will_paginate (3.1.0)
     xpath (2.0.0)
       nokogiri (~> 1.3)
@@ -467,6 +470,7 @@ DEPENDENCIES
   virtus
   web-console (~> 2.1)
   webmock
+  whenever
   will_paginate
 
 BUNDLED WITH

--- a/app/services/hwf_reference_generator.rb
+++ b/app/services/hwf_reference_generator.rb
@@ -12,9 +12,13 @@ class HwfReferenceGenerator
   def generate_reference
     begin
       reference = reference_string
-    end until OnlineApplication.find_by(reference: reference).nil?
+    end until hwf_reference_available(reference)
 
     reference
+  end
+
+  def hwf_reference_available(reference)
+    [OnlineApplication, Application].all? { |x| x.find_by(reference: reference).nil? }
   end
 
   def reference_string

--- a/app/views/public_mailer/submission_confirmation.html.slim
+++ b/app/views/public_mailer/submission_confirmation.html.slim
@@ -34,3 +34,6 @@ table cellpadding="0" cellspacing="0" border="0" width="600"
     td width="555"
       p style="padding: 0 1em 0 0; margin-bottom: 1.5em; margin-top: 0;"
         = t('email.confirmation.warning')
+  tr
+    td colspan="2"
+      p style="margin-bottom: 1.5em; margin-top: 1em;" = t('email.confirmation.expiry')

--- a/app/views/public_mailer/submission_confirmation.text.erb
+++ b/app/views/public_mailer/submission_confirmation.text.erb
@@ -15,3 +15,5 @@
 <%= t('email.confirmation.unsuccessful') %>
 
 <%= t('email.confirmation.warning') %>
+
+<%= t('email.confirmation.expiry') %>

--- a/app/views/public_mailer/submission_confirmation_et.html.slim
+++ b/app/views/public_mailer/submission_confirmation_et.html.slim
@@ -82,3 +82,6 @@ table cellpadding="0" cellspacing="0" border="0" width="600"
     td width="555"
       p style="padding: 0 1em 0 0; margin-bottom: 1.5em; margin-top: 0;"
         = t('email.et.warning')
+  tr
+    td colspan="2"
+      p style="margin-bottom: 1.5em; margin-top: 1em;" = t('email.confirmation.expiry')

--- a/app/views/public_mailer/submission_confirmation_et.text.erb
+++ b/app/views/public_mailer/submission_confirmation_et.text.erb
@@ -36,3 +36,5 @@
 <%= t('email.et.next.steps.three') %>
 
 <%= t('email.et.warning') %>
+
+<%= t('email.et.expiry') %>

--- a/app/views/public_mailer/submission_confirmation_refund.html.slim
+++ b/app/views/public_mailer/submission_confirmation_refund.html.slim
@@ -32,3 +32,6 @@ table cellpadding="0" cellspacing="0" border="0" width="600"
     td width="555"
       p style="padding: 0 1em 0 0; margin-bottom: 1.5em; margin-top: 0;"
         = t('email.refund.warning')
+  tr
+    td colspan="2"
+      p style="margin-bottom: 1.5em; margin-top: 1em;" = t('email.confirmation.expiry')

--- a/app/views/public_mailer/submission_confirmation_refund.text.erb
+++ b/app/views/public_mailer/submission_confirmation_refund.text.erb
@@ -12,3 +12,5 @@
 <%= t('email.refund.unsuccessful') %>
 
 <%= t('email.refund.warning') %>
+
+<%= t('email.refund.expiry') %>

--- a/config/locales/emails_en.yml
+++ b/config/locales/emails_en.yml
@@ -11,6 +11,7 @@ en-GB:
       send_to: '3. Deliver your claim form to the court or tribunal dealing with your case (by post or in person)'
       unsuccessful: "4. You'll hear from the court or tribunal if your application is unsuccessful or if they need more information from you."
       warning: 'Your case will not proceed until you send your reference number and claim form to the court or tribunal.'
+      expiry: 'Your help with fees reference number is valid for a single use, and expires after 3 months. Please apply again if you need further help with fees.'
     refund:
       subject: 'Application for help with fees refund'
       greeting: 'Complete your application for help with fees refund'
@@ -21,6 +22,7 @@ en-GB:
       send_to: '2. Deliver this to the court or tribunal dealing with your case (by post or in person)'
       unsuccessful: "3. You'll hear from the court or tribunal if your application is unsuccessful or if they need more information from you."
       warning: 'Your refund will not be processed until you send your reference number to the court or tribunal. '
+      expiry: 'Your help with fees reference number is valid for a single use, and expires after 3 months. Please apply again if you need further help with fees.'
     et:
       subject: 'Application for help with employment tribunal fees'
       greeting: 'Complete your application for help with fees'
@@ -67,3 +69,4 @@ en-GB:
           two: 2. You'll hear from the tribunal if your application for help with fees is unsuccessful or if they need more information from you.
           three: 3. If your application for help with fees is successful, you'll hear directly from the tribunal dealing with your case.
       warning: 'Your case will not proceed until you send your help with fees reference number and employment tribunal claim number to the tribunal.'
+      expiry: 'Your help with fees reference number is valid for a single use, and expires after 3 months. Please apply again if you need further help with fees.'

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,12 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+env :PATH, ENV['PATH']
+set :output, error: 'log/cron_error.log', standard: 'log/cron.log'
+
+job_type :rake, "cd :path && RAILS_ENV=production bundle exec rake :task :output"
+
+every 1.day, at: '2am' do
+  rake 'online_applications:purge'
+end

--- a/lib/purge_online_applications.rb
+++ b/lib/purge_online_applications.rb
@@ -1,0 +1,28 @@
+class PurgeOnlineApplications
+  attr_reader :oldest_retention_date
+
+  def initialize
+    @oldest_retention_date = Date.current - 4.months
+  end
+
+  def affected_records
+    data
+  end
+
+  def now!
+    data.destroy_all
+  end
+
+  private
+
+  def data
+    @data ||= build_data_set
+  end
+
+  def build_data_set
+    OnlineApplication.
+      joins('LEFT JOIN applications a ON a.online_application_id = online_applications.id').
+      where('online_applications.created_at < ?', @oldest_retention_date).
+      where('a.online_application_id IS NULL')
+  end
+end

--- a/lib/tasks/purge.rake
+++ b/lib/tasks/purge.rake
@@ -1,0 +1,15 @@
+namespace :online_applications do
+  desc 'Purges un-used online_applications'
+  task :purge, [] => :environment do
+    begin
+      purge = PurgeOnlineApplications.new
+      number_of = purge.affected_records.size
+      prior_to = purge.oldest_retention_date
+      puts "Purging #{number_of} online_applications created before #{prior_to}"
+      purge.now!
+    rescue => err
+      puts "online_applications error: #{err.message}"
+      raise err
+    end
+  end
+end

--- a/lib/tasks/purge.rake
+++ b/lib/tasks/purge.rake
@@ -5,7 +5,8 @@ namespace :online_applications do
       purge = PurgeOnlineApplications.new
       number_of = purge.affected_records.size
       prior_to = purge.oldest_retention_date
-      puts "Purging #{number_of} online_applications created before #{prior_to}"
+      now = Time.zone.now
+      puts "Running at: #{now}. Purging #{number_of} online_applications created before #{prior_to}"
       purge.now!
     rescue => err
       puts "online_applications error: #{err.message}"

--- a/run.sh
+++ b/run.sh
@@ -31,6 +31,12 @@ esac
 ROLE="${1:-app}"
 case ${ROLE} in
 worker)
+    echo "exporting env_vars"
+    env >> /etc/environment
+    echo "starting cron"
+    service cron start
+    echo "Creating crontab"
+    bundle exec whenever --update-crontab
     echo "running worker"
     bundle exec rake jobs:work
     ;;

--- a/run.sh
+++ b/run.sh
@@ -35,7 +35,7 @@ worker)
     env | grep -v LC_ALL >> /etc/environment
     env | grep LC_ALL >> /etc/default/locale
     echo "starting cron"
-    service cron start
+    service cron restart
     echo "Creating crontab"
     bundle exec whenever --update-crontab
     echo "running worker"

--- a/run.sh
+++ b/run.sh
@@ -32,7 +32,8 @@ ROLE="${1:-app}"
 case ${ROLE} in
 worker)
     echo "exporting env_vars"
-    env >> /etc/environment
+    env | grep -v LC_ALL >> /etc/environment
+    env | grep LC_ALL >> /etc/default/locale
     echo "starting cron"
     service cron start
     echo "Creating crontab"

--- a/spec/lib/purge_online_applications_spec.rb
+++ b/spec/lib/purge_online_applications_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe PurgeOnlineApplications do
+  subject(:service) { described_class.new }
+
+  describe '#oldest_retention_date' do
+    it 'returns 4 months prior to the current date' do
+      Timecop.freeze(Date.new(2016, 10, 01)) do
+        expect(service.oldest_retention_date).to eql Date.new(2016, 6, 1)
+      end
+    end
+  end
+
+  describe '#affected_records' do
+
+    subject { service.affected_records }
+
+    before do
+      Timecop.freeze(Time.zone.now - 5.months) do
+        create :online_application, :completed, :with_reference, convert_to_application: true
+        create :online_application, :completed, :with_reference
+      end
+    end
+
+    it 'returns online_applications older than 4 months that were not converted to applications' do
+      expect(subject.count).to eq 1
+    end
+  end
+
+  describe '#now!' do
+    before do
+      Timecop.freeze(Time.zone.now - 5.months) do
+        create :online_application, :completed, reference: 'HWF-XYX-ZWZ', convert_to_application: true
+        create :online_application, :completed, reference: 'HWF-ABA-CDC'
+      end
+      service.now!
+    end
+
+    it 'Leaves no affected records' do
+      expect(service.affected_records.count).to eq 0
+    end
+
+    it 'removes the correct record' do
+      expect(OnlineApplication.find_by(reference: 'HWF-ABA-CDC')).to be nil
+    end
+
+    it 'leaves the correct record' do
+      expect(OnlineApplication.find_by(reference: 'HWF-XYX-ZWZ')).to be_a OnlineApplication
+    end
+  end
+end

--- a/spec/services/hwf_reference_generator_spec.rb
+++ b/spec/services/hwf_reference_generator_spec.rb
@@ -22,8 +22,20 @@ RSpec.describe HwfReferenceGenerator, type: :service do
 
     context 'when the generated reference number already exists', focus: true do
       before do
-        create(:online_application, reference: 'collision')
+        create(:online_application, reference: 'collision', convert_to_application: true)
         expect(generator).to receive(:reference_string).and_return('collision', 'no-collision')
+      end
+
+      it 'keeps generating until there is no collision' do
+        expect(attributes[:reference]).to eql('no-collision')
+      end
+    end
+
+    context 'when the reference is used in the applications table' do
+      before do
+        create(:online_application, reference: 'unconverted')
+        create(:application, reference: 'converted')
+        expect(generator).to receive(:reference_string).and_return('unconverted', 'converted', 'no-collision')
       end
 
       it 'keeps generating until there is no collision' do


### PR DESCRIPTION
[Trello ticket](https://trello.com/c/EGd76BWQ/20-remove-online-applications-after-4-months-of-not-being-used)

If an online-application is completed but the number is not passed to staff within three months the application should be deleted.  The threshold is set to 4 months here to allow some time for delays in processing by the  court.

Before we purged online applications, the online_application table was the single source of truth for unused references.  Now we need to ensure that HWF-XXX-YYY isn’t used in either the
OnlineApplication or Application datasets.

### Task list
- [x] test in branch builder
- [x] code review
- [x] platforms review
- [x] test on demo
- [x] Check with content about adding expiry warning to email/done pages
- [x] get welsh translation for public app
- [ ] test on staging