### PR TITLE
RST-1421-Updating the dwp_result based on the response code

### DIFF
--- a/app/services/benefit_check_runner.rb
+++ b/app/services/benefit_check_runner.rb
@@ -41,10 +41,12 @@ class BenefitCheckRunner
   end
 
   def should_run?
-    benefit_check_date_valid? && !valid_previous_check? && (!same_as_before? || was_error?)
+    return true if benefit_check_date_valid? && !same_as_before?
+    benefit_check_date_valid? && !valid_previous_check? && was_error?
   end
 
   def was_error?
+    return false unless previous_check
     !['Yes', 'No'].include?(previous_check.dwp_result)
   end
 

--- a/app/services/benefit_check_runner.rb
+++ b/app/services/benefit_check_runner.rb
@@ -22,7 +22,7 @@ class BenefitCheckRunner
 
   def can_override?
     @benefit_check = previous_check if previous_check
-    benefit_check.blank? || benefit_check.dwp_result.blank? || overridable_result?
+    benefit_check.blank? || benefit_check.dwp_result.blank? || (overridable_result? && is_first_check?)
   end
 
   def benefit_check_date_valid?
@@ -41,6 +41,7 @@ class BenefitCheckRunner
   end
 
   def should_run?
+    is_first_check?
     return true if benefit_check_date_valid? && !same_as_before?
     benefit_check_date_valid? && !valid_previous_check? && was_error?
   end
@@ -110,4 +111,9 @@ class BenefitCheckRunner
     result = benefit_check.dwp_result.downcase
     ['no', 'server unavailable', 'undetermined', 'unspecified error'].include?(result)
   end
+
+  def is_first_check?
+    @first_check ||= (@application.benefit_checks.count == 0)
+  end
+
 end

--- a/app/services/benefit_check_runner.rb
+++ b/app/services/benefit_check_runner.rb
@@ -40,7 +40,7 @@ class BenefitCheckRunner
   end
 
   def should_run?
-    benefit_check_date_valid? && (previous_check.nil? || !same_as_before? || was_error?)
+    benefit_check_date_valid? && !valid_previous_check? && (!same_as_before? || was_error?)
   end
 
   def was_error?
@@ -48,6 +48,7 @@ class BenefitCheckRunner
   end
 
   def same_as_before?
+    return false if previous_check.blank?
     applicant_same? && (previous_check.date_to_check == benefit_check_date)
   end
 
@@ -59,6 +60,15 @@ class BenefitCheckRunner
 
   def previous_check
     @previous_check ||= @application.last_benefit_check
+  end
+
+  def valid_previous_check?
+    @previous_check ||= @application.last_benefit_check
+    return false if @previous_check.blank?
+
+    not_rerunable_resposnes = ["yes", "no", "undetermined", "deceased", "badrequest"]
+    result = @previous_check.dwp_result.downcase
+    result && not_rerunable_resposnes.include?(result)
   end
 
   def benefit_check

--- a/app/services/benefit_check_runner.rb
+++ b/app/services/benefit_check_runner.rb
@@ -22,7 +22,8 @@ class BenefitCheckRunner
 
   def can_override?
     @benefit_check = previous_check if previous_check
-    benefit_check.blank? || benefit_check.dwp_result.blank? || (overridable_result? && is_first_check?)
+    benefit_check.blank? || benefit_check.dwp_result.blank? ||
+      (overridable_result? && first_check?)
   end
 
   def benefit_check_date_valid?
@@ -41,7 +42,7 @@ class BenefitCheckRunner
   end
 
   def should_run?
-    is_first_check?
+    first_check?
     return true if benefit_check_date_valid? && !same_as_before?
     benefit_check_date_valid? && !valid_previous_check? && was_error?
   end
@@ -112,8 +113,8 @@ class BenefitCheckRunner
     ['no', 'server unavailable', 'undetermined', 'unspecified error'].include?(result)
   end
 
-  def is_first_check?
-    @first_check ||= (@application.benefit_checks.count == 0)
+  def first_check?
+    @first_check ||= @application.benefit_checks.count.zero?
   end
 
 end

--- a/app/services/benefit_check_runner.rb
+++ b/app/services/benefit_check_runner.rb
@@ -21,6 +21,7 @@ class BenefitCheckRunner
   end
 
   def can_override?
+    @benefit_check = previous_check if previous_check
     benefit_check.blank? || benefit_check.dwp_result.blank? || overridable_result?
   end
 

--- a/app/services/benefit_check_service.rb
+++ b/app/services/benefit_check_service.rb
@@ -69,8 +69,8 @@ class BenefitCheckService
     LogStuff.log @check_item.class.name.titleize.humanize, message
   end
 
-  def log_bad_request_error(e)
-    json_response = JSON.parse(e.response)['error']
+  def log_bad_request_error(error)
+    json_response = JSON.parse(error.response)['error']
     request_type = parse_response_error(json_response)
     log_error json_response, request_type
   end

--- a/spec/services/benefit_check_runner_spec.rb
+++ b/spec/services/benefit_check_runner_spec.rb
@@ -136,6 +136,40 @@ RSpec.describe BenefitCheckRunner do
           end
         end
 
+        ['Yes', 'No', 'Undetermined', 'Deceased', 'BadRequest'].each do |result|
+          context "when the DWP result is #{result}" do
+            let(:existing_benefit_check) do
+              create :benefit_check,
+                application: application,
+                last_name: applicant.last_name,
+                date_of_birth: applicant.date_of_birth + 1.day,
+                ni_number: applicant.ni_number,
+                date_to_check: detail.date_received,
+                dwp_result: result
+            end
+
+            it { expect { run }.not_to change { application.benefit_checks.count } }
+          end
+        end
+
+        ['Unspecified Error', nil].each do |result|
+          context "when the DWP result is #{result}" do
+            before{ allow(BenefitCheckService).to receive(:new) }
+
+            let(:existing_benefit_check) do
+              create :benefit_check,
+                application: application,
+                last_name: applicant.last_name,
+                date_of_birth: applicant.date_of_birth + 1.day,
+                ni_number: applicant.ni_number,
+                date_to_check: detail.date_received,
+                dwp_result: result
+            end
+
+            it { expect { run }.to change { application.benefit_checks.count } }
+          end
+        end
+
         context 'when there was an error before' do
           let(:existing_benefit_check) do
             create :benefit_check,

--- a/spec/services/benefit_check_runner_spec.rb
+++ b/spec/services/benefit_check_runner_spec.rb
@@ -260,11 +260,17 @@ RSpec.describe BenefitCheckRunner do
     context 'when the runner ran' do
       before do
         allow(service).to receive(:previous_check).and_return(benefit_check)
-        allow(service).to receive(:is_first_check?).and_return(true)
+        allow(service).to receive(:first_check?).and_return(true)
       end
 
       [
         { result: nil, overridable: true },
+        { result: 'yes', overridable: false },
+        { result: 'no', overridable: true },
+        { result: 'deceased', overridable: false },
+        { result: 'server unavailable', overridable: true },
+        { result: 'superseded', overridable: false },
+        { result: 'undetermined', overridable: true },
         { result: 'unspecified error', overridable: true }
       ].each do |definition|
         context "when result was #{definition[:result]}" do

--- a/spec/services/benefit_check_runner_spec.rb
+++ b/spec/services/benefit_check_runner_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe BenefitCheckRunner do
 
         ['Unspecified Error', nil].each do |result|
           context "when the DWP result is #{result}" do
-            before{ allow(BenefitCheckService).to receive(:new) }
+            before { allow(BenefitCheckService).to receive(:new) }
 
             let(:existing_benefit_check) do
               create :benefit_check,

--- a/spec/services/benefit_check_runner_spec.rb
+++ b/spec/services/benefit_check_runner_spec.rb
@@ -225,19 +225,24 @@ RSpec.describe BenefitCheckRunner do
   end
 
   describe '#can_override?' do
-    before do
-      allow(BenefitCheck).to receive(:create).and_return(benefit_check)
-    end
 
     subject { service.can_override? }
 
     context 'when the runner did not run' do
+      before do
+        allow(BenefitCheck).to receive(:create).and_return(benefit_check)
+      end
+
       let(:benefit_check) { nil }
 
       it { is_expected.to be true }
     end
 
     context 'when the runner ran' do
+      before do
+        allow(service).to receive(:previous_check).and_return(benefit_check)
+      end
+
       [
         { result: nil, overridable: true },
         { result: 'yes', overridable: false },

--- a/spec/services/benefit_check_runner_spec.rb
+++ b/spec/services/benefit_check_runner_spec.rb
@@ -260,16 +260,11 @@ RSpec.describe BenefitCheckRunner do
     context 'when the runner ran' do
       before do
         allow(service).to receive(:previous_check).and_return(benefit_check)
+        allow(service).to receive(:is_first_check?).and_return(true)
       end
 
       [
         { result: nil, overridable: true },
-        { result: 'yes', overridable: false },
-        { result: 'no', overridable: true },
-        { result: 'deceased', overridable: false },
-        { result: 'server unavailable', overridable: true },
-        { result: 'superseded', overridable: false },
-        { result: 'undetermined', overridable: true },
         { result: 'unspecified error', overridable: true }
       ].each do |definition|
         context "when result was #{definition[:result]}" do

--- a/spec/services/benefit_check_runner_spec.rb
+++ b/spec/services/benefit_check_runner_spec.rb
@@ -141,12 +141,12 @@ RSpec.describe BenefitCheckRunner do
           context "when the DWP result is #{result}" do
             let(:existing_benefit_check) do
               create :benefit_check,
-                application: application,
-                last_name: applicant.last_name,
-                date_of_birth: applicant.date_of_birth,
-                ni_number: applicant.ni_number,
-                date_to_check: detail.date_received,
-                dwp_result: result
+                     application: application,
+                     last_name: applicant.last_name,
+                     date_of_birth: applicant.date_of_birth,
+                     ni_number: applicant.ni_number,
+                     date_to_check: detail.date_received,
+                     dwp_result: result
             end
 
             it { expect { run }.not_to change { application.benefit_checks.count } }
@@ -159,12 +159,12 @@ RSpec.describe BenefitCheckRunner do
 
             let(:existing_benefit_check) do
               create :benefit_check,
-                application: application,
-                last_name: 'Jones',
-                date_of_birth: applicant.date_of_birth,
-                ni_number: applicant.ni_number,
-                date_to_check: detail.date_received,
-                dwp_result: result
+                     application: application,
+                     last_name: 'Jones',
+                     date_of_birth: applicant.date_of_birth,
+                     ni_number: applicant.ni_number,
+                     date_to_check: detail.date_received,
+                     dwp_result: result
             end
 
             it { expect { run }.to change { application.benefit_checks.count } }
@@ -177,12 +177,12 @@ RSpec.describe BenefitCheckRunner do
 
             let(:existing_benefit_check) do
               create :benefit_check,
-                application: application,
-                last_name: applicant.last_name,
-                date_of_birth: applicant.date_of_birth,
-                ni_number: applicant.ni_number,
-                date_to_check: detail.date_received,
-                dwp_result: result
+                     application: application,
+                     last_name: applicant.last_name,
+                     date_of_birth: applicant.date_of_birth,
+                     ni_number: applicant.ni_number,
+                     date_to_check: detail.date_received,
+                     dwp_result: result
             end
 
             it { expect { run }.to change { application.benefit_checks.count } }

--- a/spec/services/benefit_check_service_spec.rb
+++ b/spec/services/benefit_check_service_spec.rb
@@ -59,20 +59,42 @@ describe BenefitCheckService do
       end
 
       context 'simulating a 400 error' do
-        let(:message) { { 'error': "LSCBC210: Error in request parameter 'Surname'" }.to_json }
-
         before do
           stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").
             to_return(status: 400, body: message, headers: {})
           described_class.new(check)
         end
 
-        it 'returns the error in message' do
-          expect(check.error_message).to eql("LSCBC210: Error in request parameter 'Surname'")
+        context 'LSCBC210' do
+          let(:message) { { 'error': "LSCBC210: Error in request parameter 'Surname'" }.to_json }
+
+          it 'returns the error in message' do
+            expect(check.error_message).to eql("LSCBC210: Error in request parameter 'Surname'")
+          end
+
+          it 'assign dwp_result as Unspecified Error' do
+            expect(check.dwp_result).to eql("BadRequest")
+          end
+
+          it 'returns fail' do
+            expect(check.benefits_valid).to be false
+          end
         end
 
-        it 'returns fail' do
-          expect(check.benefits_valid).to be false
+        context 'LSCBC959' do
+          let(:message) { { 'error': "LSCBC959: Service unavailable" }.to_json }
+
+          it 'returns the error in message' do
+            expect(check.error_message).to eql("LSCBC959: Service unavailable")
+          end
+
+          it 'assign dwp_result as Unspecified Error' do
+            expect(check.dwp_result).to eql("Unspecified Error")
+          end
+
+          it 'returns fail' do
+            expect(check.benefits_valid).to be false
+          end
         end
       end
     end


### PR DESCRIPTION
When the BadRequest is a response from DWP and the response code is LSCBC9xx then the values stored should be "Unspecified error". Otherwise, it's "BadRequest".