### PR TITLE
Fix the finance report

### DIFF
--- a/app/builders/finance_report_builder.rb
+++ b/app/builders/finance_report_builder.rb
@@ -66,6 +66,6 @@ class FinanceReportBuilder
       exclude_hq_teams.
       joins('LEFT JOIN applications ON business_entity_id = business_entities.id').
       where('decision_date BETWEEN :d1 AND :d2', d1: @date_from, d2: @date_to).
-      where('applications.state = 3').uniq { |s| s.values_at(:office, :jurisdiction) }
+      where('applications.state = 3').distinct { |s| s.values_at(:office, :jurisdiction) }
   end
 end

--- a/spec/builders/finance_report_builder_spec.rb
+++ b/spec/builders/finance_report_builder_spec.rb
@@ -7,12 +7,6 @@ RSpec.describe FinanceReportBuilder do
   let(:business_entity) { create :business_entity }
   let(:excluded_office) { create :office, name: 'Digital' }
   let(:excluded_business_entity) { create :business_entity, office: excluded_office }
-  let(:application1) do
-    create(:application_full_remission, :processed_state, fee: 500, decision: 'full', decision_date: Time.zone.parse('2015-12-01'), business_entity: business_entity)
-  end
-  let(:application2) do
-    create(:application_full_remission, :processed_state, fee: 500, decision: 'full', decision_date: Time.zone.parse('2015-12-01'), business_entity: excluded_business_entity)
-  end
   let(:current_time) { Time.zone.parse('2016-02-02 15:50:10') }
   let(:start_date) { Time.zone.parse('2015-10-05 12:30:40') }
   let(:end_date) { Time.zone.parse('2016-01-10 16:35:00') }
@@ -27,6 +21,8 @@ RSpec.describe FinanceReportBuilder do
     it { is_expected.to be_a String }
 
     it 'does not include digital' do
+      create(:application_full_remission, :processed_state, fee: 500, decision: 'full', decision_date: Time.zone.parse('2015-12-01'), business_entity: excluded_business_entity)
+
       is_expected.not_to include('Digital')
     end
 
@@ -38,6 +34,12 @@ RSpec.describe FinanceReportBuilder do
     it 'contains dynamic meta data (dates)' do
       is_expected.to include('Period Selected:,05/10/2015-10/01/2016')
       is_expected.to include('Run:,02/02/2016 15:50')
+    end
+
+    it 'contains data for distinct business entities' do
+      create_list :application_full_remission, 2, :processed_state, fee: 500, decision: 'full', decision_date: Time.zone.parse('2015-12-01'), business_entity: business_entity
+
+      is_expected.to include(business_entity.be_code)
     end
   end
 end


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RST-2192

### Change description ###

Updating the Finance report builder to use the distinct method.

The `Relation#uniq` has been [removed](https://github.com/rails/rails/commit/adfab2dcf4003ca564d78d4425566dd2d9cd8b4f) from Rails 5+ and it's suggested to use `Relation#distinct instead.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
