### PR TITLE
Fix broken sentry event capture

### DIFF
--- a/app/controllers/applications/process/summary_controller.rb
+++ b/app/controllers/applications/process/summary_controller.rb
@@ -16,9 +16,9 @@ module Applications
         redirect_to application_confirmation_path(application.id, 'paper')
       rescue ActiveRecord::RecordInvalid => e
         flash[:alert] = I18n.t('error_messages.summary.validation')
-        Raven.capture_exception(e, application_id: @application.id)
+        Raven.capture_exception(e, extra: { application_id: application.id })
 
-        redirect_to application_summary_path(@application)
+        redirect_to application_summary_path(application)
       end
 
       private

--- a/spec/controllers/applications/process/summary_controller_spec.rb
+++ b/spec/controllers/applications/process/summary_controller_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Applications::Process::SummaryController, type: :controller do
       end
 
       it 'catch exception and notify sentry' do
-        allow(Raven).to receive(:capture_exception).with(exception, application_id: application.id)
+        allow(Raven).to receive(:capture_exception).with(exception, extra: { application_id: application.id })
         post_summary_save
       end
     end


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RST-2222

### Change description ###

Arbitrary context must be defined in the extra attribute when using `Raven.capture_exception`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
