### PR TITLE
RST-2149 - Removing line about maximum incume allowed

### DIFF
--- a/config/locales/letters_en.yml
+++ b/config/locales/letters_en.yml
@@ -21,7 +21,6 @@ en-GB:
         <p>We have received your application for help with fees. Unfortunately you’re not eligible and will have to pay the full fee. This is because you have more than the maximum amount of income allowed.
         We’ve calculated this as follows:</p>
         <p>Fee to pay: %{fee_amount}</p>
-        <p>Maximum amount of income allowed: %{income_threshold}</p>
         <p>Your income total: %{income_total}</p>
         <p><strong>If you disagree with this decision</strong></p>
         <p>If you disagree with our decision, you can appeal to the Delivery Manager at the court or tribunal dealing with your fee.</p>

--- a/spec/features/evidence/evidence_check_flow_spec.rb
+++ b/spec/features/evidence/evidence_check_flow_spec.rb
@@ -269,7 +269,7 @@ RSpec.feature 'Evidence check flow', type: :feature do
 
         it { expect(page).to have_content(evidence.amount_to_pay) }
 
-        it { expect(page).to have_content 'Maximum amount of income allowed: £5,490' }
+        it { expect(page).not_to have_content 'Maximum amount of income allowed: £5,490' }
 
         it { expect(page).to have_content 'Your income total: £2,000' }
       end


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RST-2149

### Change description ###

Improving clarity for the "declined" message based on income.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
