### PR TITLE
RST-2332 - Adding staff error details field

### DIFF
--- a/app/controllers/evidence/accuracy_failed_reason_controller.rb
+++ b/app/controllers/evidence/accuracy_failed_reason_controller.rb
@@ -24,7 +24,7 @@ module Evidence
     end
 
     def save_accuracy_reasons
-      reasons = params.require(:evidence).permit(:incorrect_reason).to_h
+      reasons = params.require(:evidence).permit(:incorrect_reason, :staff_error_details).to_h
       reasons.merge!(correct: false)
       @form.update_attributes(reasons)
       @form.save

--- a/app/controllers/evidence/accuracy_failed_reason_controller.rb
+++ b/app/controllers/evidence/accuracy_failed_reason_controller.rb
@@ -8,7 +8,7 @@ module Evidence
 
     def update
       @form = Forms::Evidence::Accuracy.new(evidence)
-      if accuracy_reasons_check && save_accuracy_reasons
+      if save_accuracy_reasons && accuracy_reasons_check
         redirect_to return_letter_evidence_path(evidence)
       else
         render :show
@@ -18,8 +18,7 @@ module Evidence
     private
 
     def accuracy_reasons_check
-      return true if params.key?(:evidence)
-      @form.errors.add(:incorrect_reason, 'Select from one of the options')
+      return true if valid_params?
       false
     end
 
@@ -30,5 +29,26 @@ module Evidence
       @form.save
     end
 
+    def valid_params?
+      return true unless params.key?(:evidence)
+      return false if blank_reasons?
+      return false if blank_error_details?
+      true
+    end
+
+    def blank_reasons?
+      return false if params[:evidence][:incorrect_reason].present?
+      @form.errors.add(:incorrect_reason, 'Select from one of the options')
+      true
+    end
+
+    def blank_error_details?
+      if params[:evidence][:incorrect_reason] == 'staff_error' &&
+         params[:evidence][:staff_error_details].blank?
+        @form.errors.add(:staff_error_details, 'Please enter details of staff error')
+        return true
+      end
+      false
+    end
   end
 end

--- a/app/models/forms/accuracy.rb
+++ b/app/models/forms/accuracy.rb
@@ -5,7 +5,8 @@ module Forms
       {
         correct: Boolean,
         incorrect_reason: String,
-        incorrect_reason_category: Array
+        incorrect_reason_category: Array,
+        staff_error_details: String
       }
     end
 

--- a/app/models/forms/evidence/accuracy.rb
+++ b/app/models/forms/evidence/accuracy.rb
@@ -6,7 +6,8 @@ module Forms
       def fields_to_update
         reset_incorrect_reasons if correct
         { correct: correct, incorrect_reason: incorrect_reason,
-          incorrect_reason_category: incorrect_reason_category }.tap do |fields|
+          incorrect_reason_category: incorrect_reason_category,
+          staff_error_details: staff_error_details }.tap do |fields|
           fields[:outcome] = 'none' unless correct
         end
       end

--- a/app/views/evidence/accuracy_failed_reason/show.html.slim
+++ b/app/views/evidence/accuracy_failed_reason/show.html.slim
@@ -19,8 +19,12 @@
             = f.radio_button :incorrect_reason, 'citizen_not_processing', class: 'govuk-radios__input'
             = f.label t('evidence.citizen_not_processing'), for: 'evidence_incorrect_reason_citizen_not_processing', class: 'govuk-label govuk-radios__label'
           .govuk-radios__item
-            = f.radio_button :incorrect_reason, 'staff_error', class: 'govuk-radios__input'
+            = f.radio_button :incorrect_reason, 'staff_error', class: 'govuk-radios__input show-hide-section', data: { section: 'error-details', show: 'false' }
             = f.label t('evidence.staff_error'), for: 'evidence_incorrect_reason_staff_error', class: 'govuk-label govuk-radios__label'
+
+        .govuk-form-group.start-hidden#error-details-only
+          = f.label :staff_error_details, t('.staff_error_details.label'), class: 'govuk-label'
+          = f.text_area :staff_error_details, class: 'govuk-textarea govuk-input--width-20', rows: "3"
 
         = f.submit 'Next', class: 'govuk-button'
 

--- a/app/views/evidence/accuracy_failed_reason/show.html.slim
+++ b/app/views/evidence/accuracy_failed_reason/show.html.slim
@@ -22,8 +22,11 @@
             = f.radio_button :incorrect_reason, 'staff_error', class: 'govuk-radios__input show-hide-section', data: { section: 'error-details', show: 'false' }
             = f.label t('evidence.staff_error'), for: 'evidence_incorrect_reason_staff_error', class: 'govuk-label govuk-radios__label'
 
-        .govuk-form-group.start-hidden#error-details-only
+        .govuk-form-group.start-hidden.group-level#error-details-only
           = f.label :staff_error_details, t('.staff_error_details.label'), class: 'govuk-label'
+          - if @form.errors[:staff_error_details].present?
+            span.govuk-error-message
+              = f.label :staff_error_details, @form.errors[:staff_error_details].join(', '), class: 'error'
           = f.text_area :staff_error_details, class: 'govuk-textarea govuk-input--width-20', rows: "3"
 
         = f.submit 'Next', class: 'govuk-button'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -118,6 +118,10 @@ en-GB:
         processed_on: Date processed
         status: Status
         updated_at: Last updated
+    accuracy_failed_reason:
+      show:
+        staff_error_details:
+          label: Please add details of the staff error
   part_payment:
     correct: 'Yes'
     incorrect: 'No'

--- a/db/migrate/20191121152746_add_staff_error_details_to_evidence_check.rb
+++ b/db/migrate/20191121152746_add_staff_error_details_to_evidence_check.rb
@@ -1,0 +1,5 @@
+class AddStaffErrorDetailsToEvidenceCheck < ActiveRecord::Migration[5.2]
+  def change
+    add_column :evidence_checks, :staff_error_details, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_24_133153) do
+ActiveRecord::Schema.define(version: 2019_11_21_152746) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -201,6 +201,7 @@ ActiveRecord::Schema.define(version: 2019_09_24_133153) do
     t.string "incorrect_reason"
     t.string "check_type"
     t.string "incorrect_reason_category"
+    t.string "staff_error_details"
     t.index ["application_id"], name: "index_evidence_checks_on_application_id"
   end
 

--- a/features/problem_with_evidence.feature
+++ b/features/problem_with_evidence.feature
@@ -24,3 +24,8 @@ Feature: Problem with evidence page
   Scenario: Problem with evidence error message
     When I click on next without making a selection
     Then I should see select from one of the options error message
+
+  Scenario: Staff error
+    When I click on staff error
+    And I submit the details of the staff error
+    Then I am taken to the rejection letter page

--- a/features/problem_with_evidence.feature
+++ b/features/problem_with_evidence.feature
@@ -29,3 +29,4 @@ Feature: Problem with evidence page
     When I click on staff error
     And I submit the details of the staff error
     Then I am taken to the rejection letter page
+    And on the processed application I can see that the reason for not being processed is staff error

--- a/features/problem_with_evidence.feature
+++ b/features/problem_with_evidence.feature
@@ -19,8 +19,9 @@ Feature: Problem with evidence page
 
   Scenario: Staff error
     When I submit the page with staff error
+    Then I submit the details of the staff error
     Then I should be taken to the return letter page
-  
+
   Scenario: Problem with evidence error message
     When I click on next without making a selection
     Then I should see select from one of the options error message

--- a/features/step_definitions/problem_with_evidence_steps.rb
+++ b/features/step_definitions/problem_with_evidence_steps.rb
@@ -51,3 +51,9 @@ When("I submit the details of the staff error") do
   fill_in 'Please add details of the staff error', with: 'These are the details of the staff error'
   next_page
 end
+
+And("on the processed application I can see that the reason for not being processed is staff error") do
+  click_button('Finish')
+  click_link('PA19-000002')
+  expect(evidence_page.content.table_row[1].text).to include 'Reason not processed: "staff_error"'
+end

--- a/features/step_definitions/problem_with_evidence_steps.rb
+++ b/features/step_definitions/problem_with_evidence_steps.rb
@@ -42,3 +42,12 @@ end
 When("I click on finish") do
   click_button('Finish')
 end
+
+When("I click on staff error") do
+  problem_with_evidence_page.content.staff_error.click
+end
+
+When("I submit the details of the staff error") do
+  fill_in 'Please add details of the staff error', with: 'These are the details of the staff error'
+  next_page
+end

--- a/features/support/page_objects/evidence_page.rb
+++ b/features/support/page_objects/evidence_page.rb
@@ -15,5 +15,6 @@ class EvidencePage < BasePage
       elements :summary_row, '.govuk-summary-list__row'
     end
     element :processing_summary, 'h2', text: 'Processing summary'
+    elements :table_row, '.govuk-table__row'
   end
 end

--- a/features/support/page_objects/problem_with_evidence_page.rb
+++ b/features/support/page_objects/problem_with_evidence_page.rb
@@ -5,6 +5,7 @@ class ProblemWithEvidencePage < BasePage
     element :not_proceeding, '.govuk-label', text: 'Citizen not proceeding'
     element :staff_error, '.govuk-label', text: 'Staff error'
     element :error, '.error', text: 'Please select from one of the options'
+    element :staff_error, '.govuk-label', text: 'Staff error'
   end
 
   def go_to_problem_with_evidence_page

--- a/spec/controllers/evidence/accuracy_failed_reason_controller_spec.rb
+++ b/spec/controllers/evidence/accuracy_failed_reason_controller_spec.rb
@@ -89,11 +89,33 @@ RSpec.describe Evidence::AccuracyFailedReasonController, type: :controller do
       end
 
       context 'when the form is empty' do
-        let(:expected_form_params) { {} }
+        let(:expected_form_params) { { correct: false } }
         let(:form_save) { true }
 
         it 'renders the incorrect reason page template again' do
           expect(response).to render_template(:show)
+        end
+
+        context 'emtpy staff error details' do
+          let(:expected_form_params) {
+            { incorrect_reason: 'staff_error', staff_error_details: '', correct: false }
+          }
+          let(:form_save) { true }
+
+          it 'renders the incorrect reason page template again' do
+            expect(response).to render_template(:show)
+          end
+        end
+
+        context 'staff error details with a content' do
+          let(:expected_form_params) {
+            { incorrect_reason: 'staff_error', staff_error_details: 'wrong ref', correct: false }
+          }
+          let(:form_save) { true }
+
+          it 'renders the incorrect reason page template again' do
+            expect(response).to redirect_to(return_letter_evidence_path(evidence))
+          end
         end
       end
     end

--- a/spec/models/forms/accuracy_spec.rb
+++ b/spec/models/forms/accuracy_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Forms::Accuracy do
   subject(:form) { described_class.new(evidence) }
 
-  params_list = [:correct, :incorrect_reason, :incorrect_reason_category]
+  params_list = [:correct, :incorrect_reason, :incorrect_reason_category, :staff_error_details]
 
   let(:evidence) { build_stubbed :evidence_check }
 

--- a/spec/models/forms/evidence/accuracy_spec.rb
+++ b/spec/models/forms/evidence/accuracy_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe Forms::Evidence::Accuracy do
     end
 
     context 'for a valid form when the evidence is incorrect' do
-      let(:params) { { correct: false } }
+      let(:staff_error_details) { 'wrong ref number' }
+      let(:params) { { correct: false, staff_error_details: staff_error_details } }
 
       before { form_save && evidence.reload }
 
@@ -51,6 +52,9 @@ RSpec.describe Forms::Evidence::Accuracy do
         expect(evidence.outcome).to eql('none')
       end
 
+      it 'updates staff_error_details' do
+        expect(evidence.staff_error_details).to eql(staff_error_details)
+      end
     end
   end
 end


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RST-2332

### Change description ###

Adding staff error details field when the evidence rejection reason is staff error

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
