### PR TITLE
Add missing variables in the letter templates page

### DIFF
--- a/app/views/reports/letters.html.slim
+++ b/app/views/reports/letters.html.slim
@@ -19,7 +19,9 @@ h2.govuk-heading-m Evidence check - received, but not correct
   = t('letters.evidence.evidence_incorrect_html',
       reference: '{AUTO: APPLICATION REFERENCE}',
       full_name: '{AUTO: APPLICANTS NAME}',
-      user_name: '{AUTO: CURRENT USERS NAME}')
+      user_name: '{AUTO: CURRENT USERS NAME}',
+      expiry_date: '{AUTO: DATE EVIDENCE DUE}',
+      amount_to_pay: '{AUTO: AMOUNT TO PAY}')
 
 h2.govuk-heading-m Evidence check - requested, but not received
 .confirmation-letter


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RST-2452

### Change description ###

There are two missing variables in the letter templates page, causing errors when visiting the page. 

This PR adds the missing variables.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
