### PR TITLE
Fixing issue with hardcoded ref number in tests

### DIFF
--- a/features/step_definitions/confirmation_steps.rb
+++ b/features/step_definitions/confirmation_steps.rb
@@ -26,7 +26,8 @@ end
 
 Then("I should see a help with fees reference number") do
   expect(confirmation_page.content).to have_reference_number_is
-  expect(confirmation_page.content).to have_reference_number
+  reference_number = "#{reference_prefix}-000001"
+  expect(confirmation_page.content.reference_number.text).to eql(reference_number)
 end
 
 Then("I should see the next steps") do

--- a/features/step_definitions/evidence_steps.rb
+++ b/features/step_definitions/evidence_steps.rb
@@ -6,7 +6,7 @@ And("there is an application waiting for evidence") do
 end
 
 And("I am on an application waiting for evidence") do
-  click_link('PA19-000002')
+  click_link("#{reference_prefix}-000002")
 end
 
 When("I click on start now to process the evidence") do

--- a/features/step_definitions/find_application_steps.rb
+++ b/features/step_definitions/find_application_steps.rb
@@ -5,7 +5,8 @@ end
 
 Then("I see that application under search results") do
   expect(find_application_page.content).to have_search_results_header
-  expect(find_application_page.content.search_results_group.found_application.text).to have_content 'PA19-000001'
+  reference = "#{reference_prefix}-000001"
+  expect(find_application_page.content.search_results_group.found_application.text).to have_content reference
 end
 
 Then("I should see the result for that full name") do
@@ -36,14 +37,14 @@ end
 
 And("that there is one result for my office") do
   result = find_application_page.content.search_results_group.found_application.result
-  expect(result[0].text).to include 'PA19'
+  expect(result[0].text).to include reference_prefix
   expect(result[1].text).to eq '1 result'
 end
 
 And("that there are two results for my office") do
   result = find_application_page.content.search_results_group.found_application.result
-  expect(result[0].text).to include 'PA19'
-  expect(result[1].text).to include 'PA19'
+  expect(result[0].text).to include reference_prefix
+  expect(result[1].text).to include reference_prefix
   expect(result[2].text).to eq '2 results'
 end
 

--- a/features/step_definitions/processed_applications_steps.rb
+++ b/features/step_definitions/processed_applications_steps.rb
@@ -1,10 +1,11 @@
 When("I click on a processed application") do
-  processed_applications_page.content.processed_application_link.click
+  processed_applications_page.content.click_link("#{reference_prefix}-000001")
 end
 
 Then("I should be taken to that application") do
   expect(current_path).to include '/processed_applications/1'
-  expect(processed_applications_page.content).to have_processed_application_header
+  header_text = processed_applications_page.content.processed_application_header.text
+  expect(header_text).to eql "#{reference_prefix}-000001 - Processed application"
 end
 
 Then("I am taken to all processed applications") do

--- a/features/step_definitions/return_letter_steps.rb
+++ b/features/step_definitions/return_letter_steps.rb
@@ -20,17 +20,20 @@ Then("I am on the return letter page after selecting staff error") do
 end
 
 Then("I should see evidence has not arrived or too late letter template") do
-  expect(return_letter_page.content.evidence_confirmation_letter.text).to include 'Reference: PA19-000002'
+  reference = "#{reference_prefix}-000002"
+  expect(return_letter_page.content.evidence_confirmation_letter.text).to include "Reference: #{reference}"
   expect(return_letter_page.content.evidence_confirmation_letter.text).to include 'As we haven’t received any information, we’re unable to process your application'
 end
 
 Then("I should see a not proceeding application letter template") do
-  expect(return_letter_page.content.evidence_confirmation_letter.text).to include 'Reference: PA19-000002'
+  reference = "#{reference_prefix}-000002"
+  expect(return_letter_page.content.evidence_confirmation_letter.text).to include "Reference: #{reference}"
   expect(return_letter_page.content.evidence_confirmation_letter.text).to include 'As you have explained that you no longer wish to proceed with your application for Help with Fees, we are returning this to you with the associated papers'
 end
 
 Then("I should see a evidence incorrect letter template") do
-  expect(return_letter_page.content.evidence_confirmation_letter.text).to include 'Reference: PA19-000002'
+  reference = "#{reference_prefix}-000002"
+  expect(return_letter_page.content.evidence_confirmation_letter.text).to include "Reference: #{reference}"
   expect(return_letter_page.content.evidence_confirmation_letter.text).to include 'There’s a problem with the documents you sent:'
   expect(return_letter_page.content.evidence_confirmation_letter.text).to include 'How to pay'
 end
@@ -65,6 +68,6 @@ end
 
 And("on the processed application I can see that the reason for not being processed is staff error") do
   click_button('Finish')
-  click_link('PA19-000002')
+  click_link("#{reference_prefix}-000002")
   expect(evidence_page.content.table_row[1].text).to include 'Reason not processed: "staff error"'
 end

--- a/features/support/generic_helpers.rb
+++ b/features/support/generic_helpers.rb
@@ -174,3 +174,7 @@ def waiting_evidence_application
   complete_processing
   back_to_start
 end
+
+def reference_prefix
+  "PA#{Time.zone.now.strftime('%y')}"
+end

--- a/features/support/page_objects/confirmation_page.rb
+++ b/features/support/page_objects/confirmation_page.rb
@@ -1,7 +1,7 @@
 class ConfirmationPage < BasePage
   section :content, '#content' do
     element :reference_number_is, '.govuk-panel__body', text: 'Reference number'
-    element :reference_number, '.reference-number', text: 'PA19-000001'
+    element :reference_number, '.reference-number'
     element :eligible, 'h2', text: '✓ Eligible for help with fees'
 
     element :next_steps_steps, 'h2', text: 'Next steps'

--- a/features/support/page_objects/find_application_page.rb
+++ b/features/support/page_objects/find_application_page.rb
@@ -37,7 +37,7 @@ class FindApplicationPage < BasePage
   end
 
   def search_by_hwf_reference
-    content.completed_search_reference.set 'PA19-000001'
+    content.completed_search_reference.set "#{reference_prefix}-000001"
     content.search_button.click
   end
 

--- a/features/support/page_objects/problem_with_evidence_page.rb
+++ b/features/support/page_objects/problem_with_evidence_page.rb
@@ -10,7 +10,7 @@ class ProblemWithEvidencePage < BasePage
   def go_to_problem_with_evidence_page
     waiting_evidence_application
     waiting_evidence_application
-    click_link('PA19-000002')
+    click_link("#{reference_prefix}-000002")
     evidence_page.content.evidence_can_not_be_processed.click
     click_link('Return application')
   end

--- a/features/support/page_objects/processed_applications_page.rb
+++ b/features/support/page_objects/processed_applications_page.rb
@@ -1,7 +1,6 @@
 class ProcessedApplicationsPage < BasePage
   section :content, '#content' do
     element :header, 'h1', text: 'Processed applications'
-    element :processed_application_header, 'h1', text: 'PA19-000001 - Processed application'
-    element :processed_application_link, 'a', text: 'PA19-000001'
+    element :processed_application_header, 'h1'
   end
 end

--- a/features/support/page_objects/reason_for_rejecting_evidence_page.rb
+++ b/features/support/page_objects/reason_for_rejecting_evidence_page.rb
@@ -14,7 +14,7 @@ class ReasonForRejectingEvidencePage < BasePage
   def go_to_reason_for_rejecting_evidence_page
     waiting_evidence_application
     waiting_evidence_application
-    click_link('PA19-000002')
+    click_link("#{reference_prefix}-000002")
     click_link('Start now')
     evidence_accuracy_page.content.problem_with_evidence.click
     next_page


### PR DESCRIPTION
Fixing cucumber test with hardcoded prefix number (based on year).

```
[ ] Yes
[x] No
```
