### PR TITLE
Renaming ccmcc_check_type to ccmcc_annotation

### DIFF
--- a/app/services/evidence_check_selector.rb
+++ b/app/services/evidence_check_selector.rb
@@ -85,7 +85,7 @@ class EvidenceCheckSelector
 
   def save_evidence_check(type)
     evidence_check_attributes = { expires_at: expires_at, check_type: type }
-    evidence_check_attributes.merge!(ccmcc_check_type: @ccmcc.check_type) if @ccmcc.try(:check_type)
+    evidence_check_attributes.merge!(ccmcc_annotation: @ccmcc.check_type) if @ccmcc.try(:check_type)
     @application.create_evidence_check(evidence_check_attributes)
   end
 

--- a/db/migrate/20200114155638_rename_ccmcc_check_type_column.rb
+++ b/db/migrate/20200114155638_rename_ccmcc_check_type_column.rb
@@ -1,0 +1,9 @@
+class RenameCcmccCheckTypeColumn < ActiveRecord::Migration[5.2]
+  def up
+    rename_column :evidence_checks, :ccmcc_check_type, :ccmcc_annotation
+  end
+
+  def down
+    rename_column :evidence_checks, :ccmcc_annotation, :ccmcc_check_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_08_154850) do
+ActiveRecord::Schema.define(version: 2020_01_14_155638) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -202,7 +202,7 @@ ActiveRecord::Schema.define(version: 2020_01_08_154850) do
     t.string "check_type"
     t.string "incorrect_reason_category"
     t.string "staff_error_details"
-    t.string "ccmcc_check_type"
+    t.string "ccmcc_annotation"
     t.index ["application_id"], name: "index_evidence_checks_on_application_id"
   end
 

--- a/spec/services/evidence_check_selector_spec.rb
+++ b/spec/services/evidence_check_selector_spec.rb
@@ -111,7 +111,7 @@ describe EvidenceCheckSelector do
           end
 
           it 'does not saves the ccmcc check type' do
-            expect(decision.ccmcc_check_type).to be nil
+            expect(decision.ccmcc_annotation).to be nil
           end
         end
 
@@ -244,7 +244,7 @@ describe EvidenceCheckSelector do
         end
 
         it 'saves the ccmcc check type' do
-          expect(decision.ccmcc_check_type).to eq('5k rule')
+          expect(decision.ccmcc_annotation).to eq('5k rule')
         end
       end
 
@@ -260,7 +260,7 @@ describe EvidenceCheckSelector do
         end
 
         it 'saves the ccmcc check type' do
-          expect(decision.ccmcc_check_type).to eq('5k rule')
+          expect(decision.ccmcc_annotation).to eq('5k rule')
         end
       end
     end


### PR DESCRIPTION
### Change description ###

Renaming evidence check column for ccmcc annotations.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
