### PR TITLE
Fixing word break in IE11

### DIFF
--- a/app/assets/stylesheets/local/layout.scss
+++ b/app/assets/stylesheets/local/layout.scss
@@ -34,4 +34,5 @@ div.govuk-panel--confirmation  {
 
 #notification .default-list.dwp-restored {
   word-break: break-word;
+  -ms-word-wrap:break-word;
 }


### PR DESCRIPTION
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
