### PR TITLE
Allow HTTP requests on the API submission endpoint

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,7 +51,7 @@ Rails.application.configure do
   config.force_ssl = true
   config.ssl_options = {
     hsts: { expires: 1.year, preload: true },
-    redirect: { exclude: ->(request) { /ping/.match?(request.path) } }
+    redirect: { exclude: ->(request) { /ping|submissions/.match?(request.path) } }
   }
 
   # Use the lowest log level to ensure availability of diagnostic information


### PR DESCRIPTION
The Staff app accepts only HTTPS requests, however the Public app uses the internal network to submit the applications. These requests are HTTP, causing Staff app to reject them. 

This exclusion will allow Staff app to receive the Public app submissions.