### PR TITLE
Enable Devise timeoutable module

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,8 @@ class User < ActiveRecord::Base
          :validatable,
          :invitable,
          :registerable,
-         :confirmable
+         :confirmable,
+         :timeoutable
 
   scope :active, -> { where('current_sign_in_at >= ?', inactivate_date) }
   scope :inactive, (lambda do

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -26,6 +26,7 @@
             .govuk-error-summary__body
               ul.govuk-list.govuk-error-summary__list
                 - flash.each do |key, value|
+                  - next unless value.is_a? String
                   li class="#{key}" data-alert='' #{value.html_safe}
 
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -189,7 +189,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = 1.hour
 
   # If true, expires auth token on session timeout.
   # config.expire_auth_token_on_timeout = false


### PR DESCRIPTION
Expire user sessions after one hour of inactivity.

Timeoutable uses the FlashHash as global storage which causes issues when displaying flash messages. The workaround is to skip non String values. See Github thread for more info https://github.com/heartcombo/devise/issues/1777

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RST-2121

### Change description ###

Expire user sessions after one hour of inactivity.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
