### PR TITLE
fix for changed behaviour of staff guides

### DIFF
--- a/spec/models/views/reports/raw_data_export_spec.rb
+++ b/spec/models/views/reports/raw_data_export_spec.rb
@@ -112,7 +112,6 @@ RSpec.describe Views::Reports::RawDataExport do
         export = data.to_csv
         jurisdiction = @part_no_ec_none_pp.detail.jurisdiction.name
         row = "#{jurisdiction},SD123,300.45,50.6,249.85,income,ABC123,,false,false,2000,3,true,part,300.45,0.0,paper"
-        # binding.pry
         expect(export).to include(row)
       end
     end


### PR DESCRIPTION

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
