### PR TITLE
Storing whole API response

### DIFF
--- a/app/services/benefit_check_service.rb
+++ b/app/services/benefit_check_service.rb
@@ -35,7 +35,7 @@ class BenefitCheckService
   rescue RestClient::BadRequest => e
     log_error JSON.parse(e.response)['error'], 'BadRequest'
   rescue Exceptions::UndeterminedDwpCheck
-    log_error @response.to_json, 'Undetermined'
+    log_error I18n.t('error_messages.benefit_checker.undetermined'), 'Undetermined'
   rescue Errno::ECONNREFUSED
     log_error I18n.t('error_messages.benefit_checker.unavailable'), 'Server unavailable'
   rescue StandardError => e
@@ -65,6 +65,7 @@ class BenefitCheckService
 
   def log_error(message, result)
     @check_item.error_message = message
+    @check_item.api_response = @response.to_json if @response
     @check_item.update!(dwp_result: result)
     LogStuff.log @check_item.class.name.titleize.humanize, message
   end

--- a/app/services/benefit_check_service.rb
+++ b/app/services/benefit_check_service.rb
@@ -35,7 +35,7 @@ class BenefitCheckService
   rescue RestClient::BadRequest => e
     log_error JSON.parse(e.response)['error'], 'BadRequest'
   rescue Exceptions::UndeterminedDwpCheck
-    log_error I18n.t('error_messages.benefit_checker.undetermined'), 'Undetermined'
+    log_error @response.to_json, 'Undetermined'
   rescue Errno::ECONNREFUSED
     log_error I18n.t('error_messages.benefit_checker.unavailable'), 'Server unavailable'
   rescue StandardError => e

--- a/db/migrate/20200623062753_add_api_response_to_benefit_checker.rb
+++ b/db/migrate/20200623062753_add_api_response_to_benefit_checker.rb
@@ -1,0 +1,5 @@
+class AddApiResponseToBenefitChecker < ActiveRecord::Migration[6.0]
+  def change
+    add_column :benefit_checks, :api_response, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_21_073854) do
+ActiveRecord::Schema.define(version: 2020_06_23_062753) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -94,6 +94,7 @@ ActiveRecord::Schema.define(version: 2020_05_21_073854) do
     t.integer "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string "api_response"
     t.index ["application_id"], name: "index_benefit_checks_on_application_id"
     t.index ["user_id"], name: "index_benefit_checks_on_user_id"
   end

--- a/spec/services/benefit_check_service_spec.rb
+++ b/spec/services/benefit_check_service_spec.rb
@@ -80,7 +80,7 @@ describe BenefitCheckService do
   end
 
   context 'called with invalid params' do
-    context 'when api_proxy returns undetermined' do
+    context 'when method returns undetermined' do
       let(:invalid_check) { create(:invalid_benefit_check) }
       before do
         dwp_api_response 'Undetermined'
@@ -93,6 +93,24 @@ describe BenefitCheckService do
 
       it 'returns fail' do
         expect(invalid_check.benefits_valid).to be false
+      end
+    end
+
+    context 'when the api returns undetermined' do
+      let(:user) { create(:user) }
+      let(:check) { create(:benefit_check, user_id: user.id, date_of_birth: '19800101', ni_number: 'AB123456A', last_name: 'LAST_NAME') }
+
+      before do
+        dwp_api_response 'Undetermined'
+        described_class.new(check)
+      end
+
+      it 'stores response as JSON in the message' do
+        expect(JSON.parse(check.error_message)['original_client_ref']).to eql('unique')
+      end
+
+      it 'returns fail' do
+        expect(check.benefits_valid).to be false
       end
     end
   end

--- a/spec/services/benefit_check_service_spec.rb
+++ b/spec/services/benefit_check_service_spec.rb
@@ -84,7 +84,7 @@ describe BenefitCheckService do
   end
 
   context 'called with invalid params' do
-    let(:api_response) { {"@xmlns"=>"https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check", "benefit_checker_status"=> status, "confirmation_ref"=>"T1426267181940", "original_client_ref"=>"unique"} }
+    let(:api_response) { { "@xmlns" => "https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check", "benefit_checker_status" => status, "confirmation_ref" => "T1426267181940", "original_client_ref" => "unique" } }
     let(:status) { 'Undetermined' }
 
     context 'when method returns undetermined' do


### PR DESCRIPTION
if the result is undetermined

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RST-2729

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
