### PR TITLE
Improved pa11y tests and added IDs to some buttons

### DIFF
--- a/app/views/home/_processed_and_deleted_aplications.html.slim
+++ b/app/views/home/_processed_and_deleted_aplications.html.slim
@@ -4,7 +4,9 @@ table.completed-applications
   tbody
     tr
       td
-        = link_to(t('processed_applications.index.title'), processed_applications_path, class: 'processed-applications')
+        = link_to(t('processed_applications.index.title'), processed_applications_path, class: 'processed-applications',
+        id: 'processed-applications')
     tr
       td
-        = link_to(t('deleted_applications.index.title'), deleted_applications_path, class: 'deleted-applications')
+        = link_to(t('deleted_applications.index.title'), deleted_applications_path, class: 'deleted-applications',
+        id: 'deleted-applications')

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -36,7 +36,7 @@ h1.visuallyhidden Help with fees - Staff application
           - else
             .govuk-form-group
               = form_tag(create_applications_path) do
-                = submit_tag 'Start now', class: 'govuk-button'
+                = submit_tag 'Start now', class: 'govuk-button', id: 'start-now'
 
       .govuk-grid-column-one-half#process-online-application
         = form_for(@online_search_form, as: :online_search, url: home_online_search_path) do |f|
@@ -102,10 +102,12 @@ h1.visuallyhidden Help with fees - Staff application
           tbody
             tr
               td
-                = link_to t("evidence.dashboard.heading"), evidence_checks_path, class: 'waiting-for-evidence'
+                = link_to t("evidence.dashboard.heading"), evidence_checks_path, class: 'waiting-for-evidence',
+                        id: 'waiting-for-evidence'
             tr
               td
-                = link_to t("part_payment.dashboard.heading"), part_payments_path, class: 'waiting-for-part_payment'
+                = link_to t("part_payment.dashboard.heading"), part_payments_path, class: 'waiting-for-part_payment',
+                        id: 'waiting-for-part-payment'
     .govuk-grid-row
       .govuk-grid-column-full
         = render('home/processed_and_deleted_aplications')

--- a/pa11y/README.md
+++ b/pa11y/README.md
@@ -17,6 +17,8 @@ webpages and highlights accessibility issues.
 
 ### Using Pa11y
 
+Install pa11y-ci using documentation at https://github.com/pa11y/pa11y-ci.
+
 For the hwf-staffapp, tests may be carried out using Admin credentials or Manager credentials
 (note: the webpages accessible to these accounts include the webpages accessible to User and Mi accounts).
 
@@ -51,7 +53,13 @@ pa11y-ci --config pa11y/tests/manager/.pa11yci.json
 ```
 
 ### Issues
-Pa11y-ci tests have been temperamental in my experience so I recommend you run each pa11y-ci command twice over in succession.
+The following field inputs will need refactoring so that they are within 3 months of the current date:
+```
+"set field #application_day_date_received to 01",
+"set field #application_month_date_received to 10",
+"set field #application_year_date_received to 2020",
+```
+This set of field inputs appear 7 times in both manager/.pa11yci_ss.json and manager/.pa11yci.json files.
 (Daniel Bell Oct.2020)
 ### WCAG standards
 

--- a/pa11y/tests/admin/.pa11yci.json
+++ b/pa11y/tests/admin/.pa11yci.json
@@ -5,7 +5,8 @@
     "viewport": {
       "width": 1000,
       "height": 1000
-    }
+    },
+    "concurrency": 1
   },
  "urls": [
    {
@@ -19,9 +20,6 @@
    {
      "url": "http://127.0.0.1:3000/users/1",
      "actions": [
-       "set field #user_email to fee-remission@digital.justice.gov.uk",
-       "set field #user_password to 123456789",
-       "click element .govuk-button",
        "navigate to http://127.0.0.1:3000/users/1"
      ]
    },

--- a/pa11y/tests/admin/.pa11yci_ss.json
+++ b/pa11y/tests/admin/.pa11yci_ss.json
@@ -5,7 +5,8 @@
     "viewport": {
       "width": 1000,
       "height": 1000
-    }
+    },
+    "concurrency": 1
   },
  "urls": [
    {

--- a/pa11y/tests/manager/.pa11yci.json
+++ b/pa11y/tests/manager/.pa11yci.json
@@ -5,72 +5,511 @@
     "viewport": {
       "width": 600,
       "height": 500
-    }
+    },
+    "concurrency": 1
   },
   "urls": [
     {
-      "url": "http://127.0.0.1:3000",
+      "url": "127.0.0.1:3000/users/sign_in",
       "actions": [
-        "set field #user_email to bristol.manager@hmcts.gsi.gov.uk",
-        "set field #user_password to 987654321",
-        "click element .govuk-button"
+        "wait for element .govuk-button to be visible"
       ]
     },
     {
-      "url": "http://127.0.0.1:3000/applications/36/personal_informations",
+      "url": "127.0.0.1:3000/?info=dashboard-page",
       "actions": [
         "set field #user_email to bristol.manager@hmcts.gsi.gov.uk",
         "set field #user_password to 987654321",
         "click element .govuk-button",
-        "navigate to http://127.0.0.1:3000/applications/36/personal_informations"
-        ]
+        "wait for element #start-now to be visible"
+      ]
     },
     {
-      "url": "http://127.0.0.1:3000/applications/36/details"
+      "url": "127.0.0.1:3000/?info=paper_app_pg1",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #start-now",
+        "wait for element #application_title to be visible"
+      ]
     },
     {
-      "url": "http://127.0.0.1:3000/applications/36/savings_investments"
+      "url": "127.0.0.1:3000/?info=paper_app_pg2",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #start-now",
+        "set field #application_title to Mr",
+        "set field #application_first_name to Waiting For",
+        "set field #application_last_name to Evidence",
+        "set field #application_day_date_of_birth to 01",
+        "set field #application_month_date_of_birth to 01",
+        "set field #application_year_date_of_birth to 1980",
+        "set field #application_ni_number to AB123456C",
+        "check field #application_married_false",
+        "click element .govuk-button",
+        "wait for element #application_fee to be visible"
+      ]
     },
     {
-      "url": "http://127.0.0.1:3000/applications/36/benefits"
+      "url": "127.0.0.1:3000/?info=paper_app_pg3",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #start-now",
+        "set field #application_title to Mr",
+        "set field #application_first_name to Waiting For",
+        "set field #application_last_name to Evidence",
+        "set field #application_day_date_of_birth to 01",
+        "set field #application_month_date_of_birth to 01",
+        "set field #application_year_date_of_birth to 1980",
+        "set field #application_ni_number to AB123456C",
+        "check field #application_married_false",
+        "click element .govuk-button",
+        "set field #application_fee to 100",
+        "check field #application_jurisdiction_id_1",
+        "set field #application_day_date_received to 01",
+        "set field #application_month_date_received to 10",
+        "set field #application_year_date_received to 2020",
+        "set field #application_form_name to C100",
+        "click element .govuk-button",
+        "wait for element #application_min_threshold_exceeded_false to be visible"
+      ]
     },
     {
-      "url": "http://127.0.0.1:3000/applications/36/incomes"
+      "url": "127.0.0.1:3000/?info=paper_app_pg4",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #start-now",
+        "set field #application_title to Mr",
+        "set field #application_first_name to Waiting For",
+        "set field #application_last_name to Evidence",
+        "set field #application_day_date_of_birth to 01",
+        "set field #application_month_date_of_birth to 01",
+        "set field #application_year_date_of_birth to 1980",
+        "set field #application_ni_number to AB123456C",
+        "check field #application_married_false",
+        "click element .govuk-button",
+        "set field #application_fee to 100",
+        "check field #application_jurisdiction_id_1",
+        "set field #application_day_date_received to 01",
+        "set field #application_month_date_received to 10",
+        "set field #application_year_date_received to 2020",
+        "set field #application_form_name to C100",
+        "click element .govuk-button",
+        "check field #application_min_threshold_exceeded_false",
+        "click element .govuk-button",
+        "wait for element #application_benefits_false to be visible"
+      ]
     },
     {
-      "url": "http://127.0.0.1:3000/applications/36/summary"
+      "url": "127.0.0.1:3000/?info=paper_app_pg5",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #start-now",
+        "set field #application_title to Mr",
+        "set field #application_first_name to Waiting For",
+        "set field #application_last_name to Evidence",
+        "set field #application_day_date_of_birth to 01",
+        "set field #application_month_date_of_birth to 01",
+        "set field #application_year_date_of_birth to 1980",
+        "set field #application_ni_number to AB123456C",
+        "check field #application_married_false",
+        "click element .govuk-button",
+        "set field #application_fee to 100",
+        "check field #application_jurisdiction_id_1",
+        "set field #application_day_date_received to 01",
+        "set field #application_month_date_received to 10",
+        "set field #application_year_date_received to 2020",
+        "set field #application_form_name to C100",
+        "click element .govuk-button",
+        "check field #application_min_threshold_exceeded_false",
+        "click element .govuk-button",
+        "check field #application_benefits_false",
+        "click element .govuk-button",
+        "wait for element #application_dependents_false to be visible"
+      ]
     },
     {
-      "url": "http://127.0.0.1:3000/applications/29/paper/confirmation"
+      "url": "127.0.0.1:3000/?info=paper_app_pg6",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #start-now",
+        "set field #application_title to Mr",
+        "set field #application_first_name to Waiting For",
+        "set field #application_last_name to Evidence",
+        "set field #application_day_date_of_birth to 01",
+        "set field #application_month_date_of_birth to 01",
+        "set field #application_year_date_of_birth to 1980",
+        "set field #application_ni_number to AB123456C",
+        "check field #application_married_false",
+        "click element .govuk-button",
+        "set field #application_fee to 100",
+        "check field #application_jurisdiction_id_1",
+        "set field #application_day_date_received to 01",
+        "set field #application_month_date_received to 10",
+        "set field #application_year_date_received to 2020",
+        "set field #application_form_name to C100",
+        "click element .govuk-button",
+        "check field #application_min_threshold_exceeded_false",
+        "click element .govuk-button",
+        "check field #application_benefits_false",
+        "click element .govuk-button",
+        "check field #application_dependents_false",
+        "set field #application_income to 1000",
+        "click element .govuk-button",
+        "wait for element .govuk-button to be visible"
+      ]
     },
     {
-      "url": "http://127.0.0.1:3000/processed_applications"
+      "url": "127.0.0.1:3000/?info=paper_app_pg7",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #start-now",
+        "set field #application_title to Mr",
+        "set field #application_first_name to Waiting For",
+        "set field #application_last_name to Evidence",
+        "set field #application_day_date_of_birth to 01",
+        "set field #application_month_date_of_birth to 01",
+        "set field #application_year_date_of_birth to 1980",
+        "set field #application_ni_number to AB123456C",
+        "check field #application_married_false",
+        "click element .govuk-button",
+        "set field #application_fee to 100",
+        "check field #application_jurisdiction_id_1",
+        "set field #application_day_date_received to 01",
+        "set field #application_month_date_received to 10",
+        "set field #application_year_date_received to 2020",
+        "set field #application_form_name to C100",
+        "click element .govuk-button",
+        "check field #application_min_threshold_exceeded_false",
+        "click element .govuk-button",
+        "check field #application_benefits_false",
+        "click element .govuk-button",
+        "check field #application_dependents_false",
+        "set field #application_income to 1000",
+        "click element .govuk-button",
+        "wait for element .govuk-button to be visible",
+        "click element .govuk-button",
+        "wait for element #result to be visible"
+      ]
     },
     {
-      "url": "http://127.0.0.1:3000/processed_applications/29"
+      "url": "127.0.0.1:3000/?info=waiting_for_evidence_list",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #waiting-for-evidence",
+        "wait for element .govuk-heading-m.heading-icon.util_mt-medium.util_mb-0.heading-icon-evidence to be visible"
+      ]
     },
     {
-      "url": "http://127.0.0.1:3000/online_applications/11/edit"
+      "url": "127.0.0.1:3000/?info=waiting_for_evidence_instance",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #waiting-for-evidence",
+        "wait for element .govuk-heading-m.heading-icon.util_mt-medium.util_mb-0.heading-icon-evidence to be visible",
+        "click element td > a",
+        "wait for element #result to be visible"
+      ]
     },
     {
-      "url": "http://127.0.0.1:3000/online_applications/11"
+      "url": "127.0.0.1:3000/?info=waiting_for_evidence_accuracy",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #waiting-for-evidence",
+        "wait for element .govuk-heading-m.heading-icon.util_mt-medium.util_mb-0.heading-icon-evidence to be visible",
+        "click element td > a",
+        "wait for element #result to be visible",
+        "click element .govuk-button.util_mb-medium",
+        "wait for element .govuk-heading-xl to be visible"
+      ]
     },
     {
-      "url": "http://127.0.0.1:3000/applications/37/digital/confirmation"
+      "url": "127.0.0.1:3000/?info=waiting_for_evidence_yes_path_income",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #waiting-for-evidence",
+        "wait for element .govuk-heading-m.heading-icon.util_mt-medium.util_mb-0.heading-icon-evidence to be visible",
+        "click element td > a",
+        "wait for element #result to be visible",
+        "click element .govuk-button.util_mb-medium",
+        "wait for element .govuk-heading-xl to be visible",
+        "check field #evidence_correct_true",
+        "click element .govuk-button",
+        "wait for element #evidence_income to be visible"
+      ]
     },
     {
-      "url": "http://127.0.0.1:3000/feedback"
+      "url": "127.0.0.1:3000/?info=waiting_for_evidence_yes_path_result",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #waiting-for-evidence",
+        "wait for element .govuk-heading-m.heading-icon.util_mt-medium.util_mb-0.heading-icon-evidence to be visible",
+        "click element td > a",
+        "wait for element #result to be visible",
+        "click element .govuk-button.util_mb-medium",
+        "wait for element .govuk-heading-xl to be visible",
+        "check field #evidence_correct_true",
+        "click element .govuk-button",
+        "wait for element #evidence_income to be visible",
+        "set field #evidence_income to 1000",
+        "click element .govuk-button",
+        "wait for element #result to be visible"
+      ]
     },
     {
-      "url": "http://127.0.0.1:3000/evidence_checks"
+      "url": "127.0.0.1:3000/?info=waiting_for_evidence_yes_path_summary",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #waiting-for-evidence",
+        "wait for element .govuk-heading-m.heading-icon.util_mt-medium.util_mb-0.heading-icon-evidence to be visible",
+        "click element td > a",
+        "wait for element #result to be visible",
+        "click element .govuk-button.util_mb-medium",
+        "wait for element .govuk-heading-xl to be visible",
+        "check field #evidence_correct_true",
+        "click element .govuk-button",
+        "wait for element #evidence_income to be visible",
+        "set field #evidence_income to 1000",
+        "click element .govuk-button",
+        "wait for element #result to be visible",
+        "click element .govuk-button",
+        "wait for element #result to be visible"
+      ]
     },
     {
-      "url": "http://127.0.0.1:3000/part_payments"
+      "url": "127.0.0.1:3000/?info=waiting_for_evidence_no_path_reason",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #waiting-for-evidence",
+        "wait for element .govuk-heading-m.heading-icon.util_mt-medium.util_mb-0.heading-icon-evidence to be visible",
+        "click element td > a",
+        "wait for element #result to be visible",
+        "click element .govuk-button.util_mb-medium",
+        "wait for element .govuk-heading-xl to be visible",
+        "check field #evidence_correct_false",
+        "click element .govuk-button",
+        "wait for element #evidence_incorrect_reason_category_requested_source_not_provided to be visible"
+      ]
     },
     {
-      "url": "http://127.0.0.1:3000/deleted_applications"
+      "url": "127.0.0.1:3000/?info=waiting_for_evidence_no_path_summary",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #waiting-for-evidence",
+        "wait for element .govuk-heading-m.heading-icon.util_mt-medium.util_mb-0.heading-icon-evidence to be visible",
+        "click element td > a",
+        "wait for element #result to be visible",
+        "click element .govuk-button.util_mb-medium",
+        "wait for element .govuk-heading-xl to be visible",
+        "check field #evidence_correct_false",
+        "click element .govuk-button",
+        "wait for element #evidence_incorrect_reason_category_requested_source_not_provided to be visible",
+        "check field #evidence_incorrect_reason_category_requested_source_not_provided",
+        "check field #evidence_incorrect_reason_category_wrong_type_provided",
+        "click element .govuk-button",
+        "wait for element #result to be visible"
+      ]
+    },
+    {
+      "url": "127.0.0.1:3000/?info=waiting_for_evidence_no_path_complete_processing",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #waiting-for-evidence",
+        "wait for element .govuk-heading-m.heading-icon.util_mt-medium.util_mb-0.heading-icon-evidence to be visible",
+        "click element td > a",
+        "wait for element #result to be visible",
+        "click element .govuk-button.util_mb-medium",
+        "wait for element .govuk-heading-xl to be visible",
+        "check field #evidence_correct_false",
+        "click element .govuk-button",
+        "wait for element #evidence_incorrect_reason_category_requested_source_not_provided to be visible",
+        "check field #evidence_incorrect_reason_category_requested_source_not_provided",
+        "check field #evidence_incorrect_reason_category_wrong_type_provided",
+        "click element .govuk-button",
+        "wait for element #result to be visible",
+        "click element .govuk-button.primary.large",
+        "wait for element .evidence-confirmation-letter to be visible"
+      ]
+    },
+    {
+      "url": "127.0.0.1:3000/?info=processed_applications_list",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #processed-applications",
+        "wait for element .govuk-heading-xl to be visible"
+      ]
+    },
+    {
+      "url": "127.0.0.1:3000/?info=processed_application_instance",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #processed-applications",
+        "wait for element .govuk-heading-xl to be visible",
+        "click element td > a",
+        "wait for element .govuk-details__summary-text to be visible"
+      ]
+    },
+    {
+      "url": "127.0.0.1:3000/?info=deleting_application",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #processed-applications",
+        "wait for element .govuk-heading-xl to be visible",
+        "click element td > a",
+        "wait for element .govuk-details__summary-text to be visible",
+        "click element .govuk-details__summary-text",
+        "set field #application_deleted_reason to test",
+        "click element .govuk-button",
+        "wait for element .govuk-error-summary to be visible"
+      ]
+    },
+    {
+      "url": "127.0.0.1:3000/?info=deleted_application_instance",
+      "actions": [
+        "wait for element #deleted-applications to be visible",
+        "click element #deleted-applications",
+        "wait for element .govuk-heading-xl to be visible",
+        "click element td > a",
+        "wait for element #result to be visible"
+      ]
+    },
+    {
+      "url": "127.0.0.1:3000/?info=paper_app_part_payment_to_completion",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #start-now",
+        "set field #application_title to Mr",
+        "set field #application_first_name to Part",
+        "set field #application_last_name to Payment",
+        "set field #application_day_date_of_birth to 01",
+        "set field #application_month_date_of_birth to 01",
+        "set field #application_year_date_of_birth to 1980",
+        "set field #application_ni_number to AB123456C",
+        "check field #application_married_false",
+        "click element .govuk-button",
+        "set field #application_fee to 111",
+        "check field #application_jurisdiction_id_1",
+        "set field #application_day_date_received to 01",
+        "set field #application_month_date_received to 10",
+        "set field #application_year_date_received to 2020",
+        "set field #application_form_name to C100",
+        "click element .govuk-button",
+        "check field #application_min_threshold_exceeded_false",
+        "click element .govuk-button",
+        "check field #application_benefits_false",
+        "click element .govuk-button",
+        "check field #application_dependents_false",
+        "set field #application_income to 1110",
+        "click element .govuk-button",
+        "wait for element .govuk-button to be visible",
+        "click element .govuk-button",
+        "wait for element #result to be visible"
+      ]
+    },
+    {
+      "url": "127.0.0.1:3000/?info=part_payment_app_waiting_for_evidence_result",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element td > a",
+        "wait for element #result to be visible",
+        "click element .govuk-button.util_mb-medium",
+        "wait for element .govuk-heading-xl to be visible",
+        "check field #evidence_correct_true",
+        "click element .govuk-button",
+        "wait for element #evidence_income to be visible",
+        "set field #evidence_income to 1110",
+        "click element .govuk-button",
+        "wait for element #result to be visible"
+      ]
+    },
+    {
+      "url": "127.0.0.1:3000/?info=part_payment_app_waiting_for_evidence_complete_processing",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element td > a",
+        "wait for element #result to be visible",
+        "click element .govuk-button.util_mb-medium",
+        "wait for element .govuk-heading-xl to be visible",
+        "click element .govuk-button",
+        "wait for element #evidence_income to be visible",
+        "click element .govuk-button",
+        "wait for element #result to be visible",
+        "click element .govuk-button",
+        "wait for element #result to be visible",
+        "click element .govuk-button.primary.large",
+        "wait for element .govuk-panel.govuk-panel--confirmation to be visible"
+      ]
+    },
+    {
+      "url": "127.0.0.1:3000/?info=waiting_for_part_payment_accuracy",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #waiting-for-part-payment",
+        "wait for .govuk-heading-m.heading-icon.util_mt-medium.util_mb-0.heading-icon-part_payment to be visible",
+        "click element td > a",
+        "wait for element .govuk-heading-xl to be visible",
+        "click element .govuk-button.util_mb-medium",
+        "wait for element .govuk-heading-xl to be visible"
+      ]
+    },
+    {
+      "url": "127.0.0.1:3000/?info=waiting_for_part_payment_summary",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #waiting-for-part-payment",
+        "wait for .govuk-heading-m.heading-icon.util_mt-medium.util_mb-0.heading-icon-part_payment to be visible",
+        "click element td > a",
+        "wait for element .govuk-heading-xl to be visible",
+        "click element .govuk-button.util_mb-medium",
+        "wait for element .govuk-heading-xl to be visible",
+        "check field #part_payment_correct_true",
+        "click element .govuk-button",
+        "wait for element #result to be visible"
+      ]
+    },
+    {
+      "url": "127.0.0.1:3000/?info=waiting_for_part_payment_confirmation",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #waiting-for-part-payment",
+        "wait for .govuk-heading-m.heading-icon.util_mt-medium.util_mb-0.heading-icon-part_payment to be visible",
+        "click element td > a",
+        "wait for element .govuk-heading-xl to be visible",
+        "click element .govuk-button.util_mb-medium",
+        "wait for element .govuk-heading-xl to be visible",
+        "check field #part_payment_correct_true",
+        "click element .govuk-button",
+        "wait for element #result to be visible",
+        "click element .govuk-button.primary.large",
+        "wait for element .govuk-panel.govuk-panel--confirmation to be visible"
+      ]
+    },
+    {
+      "url": "127.0.0.1:3000/?info=paper_app_not_eligible_to_completion",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #start-now",
+        "set field #application_title to Mr",
+        "set field #application_first_name to Not",
+        "set field #application_last_name to Eligible",
+        "set field #application_day_date_of_birth to 01",
+        "set field #application_month_date_of_birth to 01",
+        "set field #application_year_date_of_birth to 1980",
+        "set field #application_ni_number to AB123456C",
+        "check field #application_married_false",
+        "click element .govuk-button",
+        "set field #application_fee to 111",
+        "check field #application_jurisdiction_id_1",
+        "set field #application_day_date_received to 01",
+        "set field #application_month_date_received to 10",
+        "set field #application_year_date_received to 2020",
+        "set field #application_form_name to C100",
+        "click element .govuk-button",
+        "check field #application_min_threshold_exceeded_true",
+        "set field #application_amount to 100000",
+        "click element .govuk-button",
+        "wait for element .govuk-button to be visible",
+        "click element .govuk-button",
+        "wait for element #result to be visible"
+      ]
     }
   ]
 }
-
-

--- a/pa11y/tests/manager/.pa11yci_ss.json
+++ b/pa11y/tests/manager/.pa11yci_ss.json
@@ -5,119 +5,540 @@
     "viewport": {
       "width": 600,
       "height": 500
-    }
+    },
+    "concurrency": 1
   },
   "urls": [
     {
-      "url": "http://127.0.0.1:3000",
+      "url": "127.0.0.1:3000/users/sign_in",
       "actions": [
-        "set field #user_email to bristol.manager@hmcts.gsi.gov.uk",
-        "set field #user_password to 987654321",
-        "click element .govuk-button",
-        "screen capture pa11y/screenshots/manager/home_page.png"
+        "wait for element .govuk-button to be visible",
+        "screen capture pa11y/screenshots/manager/sign-in-page.png"
       ]
     },
     {
-      "url": "http://127.0.0.1:3000/applications/36/personal_informations",
+      "url": "127.0.0.1:3000/?info=dashboard-page",
       "actions": [
         "set field #user_email to bristol.manager@hmcts.gsi.gov.uk",
         "set field #user_password to 987654321",
         "click element .govuk-button",
-        "navigate to http://127.0.0.1:3000/applications/36/personal_informations",
+        "wait for element #start-now to be visible",
+        "screen capture pa11y/screenshots/manager/dashboard-page.png"
+      ]
+    },
+    {
+      "url": "127.0.0.1:3000/?info=paper_app_pg1",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #start-now",
+        "wait for element #application_title to be visible",
         "screen capture pa11y/screenshots/manager/paper_app_pg1.png"
       ]
     },
     {
-      "url": "http://127.0.0.1:3000/applications/36/details",
+      "url": "127.0.0.1:3000/?info=paper_app_pg2",
       "actions": [
+        "wait for element #start-now to be visible",
+        "click element #start-now",
+        "set field #application_title to Mr",
+        "set field #application_first_name to Waiting For",
+        "set field #application_last_name to Evidence",
+        "set field #application_day_date_of_birth to 01",
+        "set field #application_month_date_of_birth to 01",
+        "set field #application_year_date_of_birth to 1980",
+        "set field #application_ni_number to AB123456C",
+        "check field #application_married_false",
+        "click element .govuk-button",
+        "wait for element #application_fee to be visible",
         "screen capture pa11y/screenshots/manager/paper_app_pg2.png"
       ]
     },
     {
-      "url": "http://127.0.0.1:3000/applications/36/savings_investments",
+      "url": "127.0.0.1:3000/?info=paper_app_pg3",
       "actions": [
+        "wait for element #start-now to be visible",
+        "click element #start-now",
+        "set field #application_title to Mr",
+        "set field #application_first_name to Waiting For",
+        "set field #application_last_name to Evidence",
+        "set field #application_day_date_of_birth to 01",
+        "set field #application_month_date_of_birth to 01",
+        "set field #application_year_date_of_birth to 1980",
+        "set field #application_ni_number to AB123456C",
+        "check field #application_married_false",
+        "click element .govuk-button",
+        "set field #application_fee to 100",
+        "check field #application_jurisdiction_id_1",
+        "set field #application_day_date_received to 01",
+        "set field #application_month_date_received to 10",
+        "set field #application_year_date_received to 2020",
+        "set field #application_form_name to C100",
+        "click element .govuk-button",
+        "wait for element #application_min_threshold_exceeded_false to be visible",
         "screen capture pa11y/screenshots/manager/paper_app_pg3.png"
       ]
     },
     {
-      "url": "http://127.0.0.1:3000/applications/36/benefits",
+      "url": "127.0.0.1:3000/?info=paper_app_pg4",
       "actions": [
+        "wait for element #start-now to be visible",
+        "click element #start-now",
+        "set field #application_title to Mr",
+        "set field #application_first_name to Waiting For",
+        "set field #application_last_name to Evidence",
+        "set field #application_day_date_of_birth to 01",
+        "set field #application_month_date_of_birth to 01",
+        "set field #application_year_date_of_birth to 1980",
+        "set field #application_ni_number to AB123456C",
+        "check field #application_married_false",
+        "click element .govuk-button",
+        "set field #application_fee to 100",
+        "check field #application_jurisdiction_id_1",
+        "set field #application_day_date_received to 01",
+        "set field #application_month_date_received to 10",
+        "set field #application_year_date_received to 2020",
+        "set field #application_form_name to C100",
+        "click element .govuk-button",
+        "check field #application_min_threshold_exceeded_false",
+        "click element .govuk-button",
+        "wait for element #application_benefits_false to be visible",
         "screen capture pa11y/screenshots/manager/paper_app_pg4.png"
       ]
     },
     {
-      "url": "http://127.0.0.1:3000/applications/36/incomes",
+      "url": "127.0.0.1:3000/?info=paper_app_pg5",
       "actions": [
+        "wait for element #start-now to be visible",
+        "click element #start-now",
+        "set field #application_title to Mr",
+        "set field #application_first_name to Waiting For",
+        "set field #application_last_name to Evidence",
+        "set field #application_day_date_of_birth to 01",
+        "set field #application_month_date_of_birth to 01",
+        "set field #application_year_date_of_birth to 1980",
+        "set field #application_ni_number to AB123456C",
+        "check field #application_married_false",
+        "click element .govuk-button",
+        "set field #application_fee to 100",
+        "check field #application_jurisdiction_id_1",
+        "set field #application_day_date_received to 01",
+        "set field #application_month_date_received to 10",
+        "set field #application_year_date_received to 2020",
+        "set field #application_form_name to C100",
+        "click element .govuk-button",
+        "check field #application_min_threshold_exceeded_false",
+        "click element .govuk-button",
+        "check field #application_benefits_false",
+        "click element .govuk-button",
+        "wait for element #application_dependents_false to be visible",
         "screen capture pa11y/screenshots/manager/paper_app_pg5.png"
       ]
     },
     {
-      "url": "http://127.0.0.1:3000/applications/36/summary",
+      "url": "127.0.0.1:3000/?info=paper_app_pg6",
       "actions": [
+        "wait for element #start-now to be visible",
+        "click element #start-now",
+        "set field #application_title to Mr",
+        "set field #application_first_name to Waiting For",
+        "set field #application_last_name to Evidence",
+        "set field #application_day_date_of_birth to 01",
+        "set field #application_month_date_of_birth to 01",
+        "set field #application_year_date_of_birth to 1980",
+        "set field #application_ni_number to AB123456C",
+        "check field #application_married_false",
+        "click element .govuk-button",
+        "set field #application_fee to 100",
+        "check field #application_jurisdiction_id_1",
+        "set field #application_day_date_received to 01",
+        "set field #application_month_date_received to 10",
+        "set field #application_year_date_received to 2020",
+        "set field #application_form_name to C100",
+        "click element .govuk-button",
+        "check field #application_min_threshold_exceeded_false",
+        "click element .govuk-button",
+        "check field #application_benefits_false",
+        "click element .govuk-button",
+        "check field #application_dependents_false",
+        "set field #application_income to 1000",
+        "click element .govuk-button",
+        "wait for element .govuk-button to be visible",
         "screen capture pa11y/screenshots/manager/paper_app_pg6.png"
       ]
     },
     {
-      "url": "http://127.0.0.1:3000/applications/29/paper/confirmation",
+      "url": "127.0.0.1:3000/?info=paper_app_pg7",
       "actions": [
+        "wait for element #start-now to be visible",
+        "click element #start-now",
+        "set field #application_title to Mr",
+        "set field #application_first_name to Waiting For",
+        "set field #application_last_name to Evidence",
+        "set field #application_day_date_of_birth to 01",
+        "set field #application_month_date_of_birth to 01",
+        "set field #application_year_date_of_birth to 1980",
+        "set field #application_ni_number to AB123456C",
+        "check field #application_married_false",
+        "click element .govuk-button",
+        "set field #application_fee to 100",
+        "check field #application_jurisdiction_id_1",
+        "set field #application_day_date_received to 01",
+        "set field #application_month_date_received to 10",
+        "set field #application_year_date_received to 2020",
+        "set field #application_form_name to C100",
+        "click element .govuk-button",
+        "check field #application_min_threshold_exceeded_false",
+        "click element .govuk-button",
+        "check field #application_benefits_false",
+        "click element .govuk-button",
+        "check field #application_dependents_false",
+        "set field #application_income to 1000",
+        "click element .govuk-button",
+        "wait for element .govuk-button to be visible",
+        "click element .govuk-button",
+        "wait for element #result to be visible",
         "screen capture pa11y/screenshots/manager/paper_app_pg7.png"
       ]
     },
     {
-      "url": "http://127.0.0.1:3000/processed_applications",
+      "url": "127.0.0.1:3000/?info=waiting_for_evidence_list",
       "actions": [
-        "screen capture pa11y/screenshots/manager/proc_apps.png"
+        "wait for element #start-now to be visible",
+        "click element #waiting-for-evidence",
+        "wait for element .govuk-heading-m.heading-icon.util_mt-medium.util_mb-0.heading-icon-evidence to be visible",
+        "screen capture pa11y/screenshots/manager/waiting_for_evidence_list.png"
       ]
     },
     {
-      "url": "http://127.0.0.1:3000/processed_applications/29",
+      "url": "127.0.0.1:3000/?info=waiting_for_evidence_instance",
       "actions": [
-        "screen capture pa11y/screenshots/manager/proc_app_detail.png"
+        "wait for element #start-now to be visible",
+        "click element #waiting-for-evidence",
+        "wait for element .govuk-heading-m.heading-icon.util_mt-medium.util_mb-0.heading-icon-evidence to be visible",
+        "click element td > a",
+        "wait for element #result to be visible",
+        "screen capture pa11y/screenshots/manager/waiting_for_evidence_instance.png"
       ]
     },
     {
-      "url": "http://127.0.0.1:3000/online_applications/11/edit",
+      "url": "127.0.0.1:3000/?info=waiting_for_evidence_accuracy",
       "actions": [
-        "screen capture pa11y/screenshots/manager/online_app_edit.png"
+        "wait for element #start-now to be visible",
+        "click element #waiting-for-evidence",
+        "wait for element .govuk-heading-m.heading-icon.util_mt-medium.util_mb-0.heading-icon-evidence to be visible",
+        "click element td > a",
+        "wait for element #result to be visible",
+        "click element .govuk-button.util_mb-medium",
+        "wait for element .govuk-heading-xl to be visible",
+        "screen capture pa11y/screenshots/manager/waiting_for_evidence_accuracy.png"
       ]
     },
     {
-      "url": "http://127.0.0.1:3000/online_applications/11",
+      "url": "127.0.0.1:3000/?info=waiting_for_evidence_yes_path_income",
       "actions": [
-        "screen capture pa11y/screenshots/manager/online_app_end.png"
+        "wait for element #start-now to be visible",
+        "click element #waiting-for-evidence",
+        "wait for element .govuk-heading-m.heading-icon.util_mt-medium.util_mb-0.heading-icon-evidence to be visible",
+        "click element td > a",
+        "wait for element #result to be visible",
+        "click element .govuk-button.util_mb-medium",
+        "wait for element .govuk-heading-xl to be visible",
+        "check field #evidence_correct_true",
+        "click element .govuk-button",
+        "wait for element #evidence_income to be visible",
+        "screen capture pa11y/screenshots/manager/waiting_for_evidence_yes_path_income.png"
       ]
     },
     {
-      "url": "http://127.0.0.1:3000/applications/37/digital/confirmation",
+      "url": "127.0.0.1:3000/?info=waiting_for_evidence_yes_path_result",
       "actions": [
-        "screen capture pa11y/screenshots/manager/online_app_conf.png"
+        "wait for element #start-now to be visible",
+        "click element #waiting-for-evidence",
+        "wait for element .govuk-heading-m.heading-icon.util_mt-medium.util_mb-0.heading-icon-evidence to be visible",
+        "click element td > a",
+        "wait for element #result to be visible",
+        "click element .govuk-button.util_mb-medium",
+        "wait for element .govuk-heading-xl to be visible",
+        "check field #evidence_correct_true",
+        "click element .govuk-button",
+        "wait for element #evidence_income to be visible",
+        "set field #evidence_income to 1000",
+        "click element .govuk-button",
+        "wait for element #result to be visible",
+        "screen capture pa11y/screenshots/manager/waiting_for_evidence_yes_path_result.png"
       ]
     },
     {
-      "url": "http://127.0.0.1:3000/feedback",
+      "url": "127.0.0.1:3000/?info=waiting_for_evidence_yes_path_summary",
       "actions": [
-        "screen capture pa11y/screenshots/manager/feedback_form.png"
+        "wait for element #start-now to be visible",
+        "click element #waiting-for-evidence",
+        "wait for element .govuk-heading-m.heading-icon.util_mt-medium.util_mb-0.heading-icon-evidence to be visible",
+        "click element td > a",
+        "wait for element #result to be visible",
+        "click element .govuk-button.util_mb-medium",
+        "wait for element .govuk-heading-xl to be visible",
+        "check field #evidence_correct_true",
+        "click element .govuk-button",
+        "wait for element #evidence_income to be visible",
+        "set field #evidence_income to 1000",
+        "click element .govuk-button",
+        "wait for element #result to be visible",
+        "click element .govuk-button",
+        "wait for element #result to be visible",
+        "screen capture pa11y/screenshots/manager/waiting_for_evidence_yes_path_summary.png"
       ]
     },
     {
-      "url": "http://127.0.0.1:3000/evidence_checks",
+      "url": "127.0.0.1:3000/?info=waiting_for_evidence_no_path_reason",
       "actions": [
-        "screen capture pa11y/screenshots/manager/evidence_checks.png"
+        "wait for element #start-now to be visible",
+        "click element #waiting-for-evidence",
+        "wait for element .govuk-heading-m.heading-icon.util_mt-medium.util_mb-0.heading-icon-evidence to be visible",
+        "click element td > a",
+        "wait for element #result to be visible",
+        "click element .govuk-button.util_mb-medium",
+        "wait for element .govuk-heading-xl to be visible",
+        "check field #evidence_correct_false",
+        "click element .govuk-button",
+        "wait for element #evidence_incorrect_reason_category_requested_source_not_provided to be visible",
+        "screen capture pa11y/screenshots/manager/waiting_for_evidence_no_path_reason.png"
       ]
     },
     {
-      "url": "http://127.0.0.1:3000/part_payments",
+      "url": "127.0.0.1:3000/?info=waiting_for_evidence_no_path_summary",
       "actions": [
-        "screen capture pa11y/screenshots/manager/part_payments.png"
+        "wait for element #start-now to be visible",
+        "click element #waiting-for-evidence",
+        "wait for element .govuk-heading-m.heading-icon.util_mt-medium.util_mb-0.heading-icon-evidence to be visible",
+        "click element td > a",
+        "wait for element #result to be visible",
+        "click element .govuk-button.util_mb-medium",
+        "wait for element .govuk-heading-xl to be visible",
+        "check field #evidence_correct_false",
+        "click element .govuk-button",
+        "wait for element #evidence_incorrect_reason_category_requested_source_not_provided to be visible",
+        "check field #evidence_incorrect_reason_category_requested_source_not_provided",
+        "check field #evidence_incorrect_reason_category_wrong_type_provided",
+        "click element .govuk-button",
+        "wait for element #result to be visible",
+        "screen capture pa11y/screenshots/manager/waiting_for_evidence_no_path_summary.png"
       ]
     },
     {
-      "url": "http://127.0.0.1:3000/deleted_applications",
+      "url": "127.0.0.1:3000/?info=waiting_for_evidence_no_path_complete_processing",
       "actions": [
-        "screen capture pa11y/screenshots/manager/deleted_applications.png"
+        "wait for element #start-now to be visible",
+        "click element #waiting-for-evidence",
+        "wait for element .govuk-heading-m.heading-icon.util_mt-medium.util_mb-0.heading-icon-evidence to be visible",
+        "click element td > a",
+        "wait for element #result to be visible",
+        "click element .govuk-button.util_mb-medium",
+        "wait for element .govuk-heading-xl to be visible",
+        "check field #evidence_correct_false",
+        "click element .govuk-button",
+        "wait for element #evidence_incorrect_reason_category_requested_source_not_provided to be visible",
+        "check field #evidence_incorrect_reason_category_requested_source_not_provided",
+        "check field #evidence_incorrect_reason_category_wrong_type_provided",
+        "click element .govuk-button",
+        "wait for element #result to be visible",
+        "click element .govuk-button.primary.large",
+        "wait for element .evidence-confirmation-letter to be visible",
+        "screen capture pa11y/screenshots/manager/waiting_for_evidence_no_path_complete_processing.png"
+      ]
+    },
+    {
+      "url": "127.0.0.1:3000/?info=processed_applications_list",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #processed-applications",
+        "wait for element .govuk-heading-xl to be visible",
+        "screen capture pa11y/screenshots/manager/processed_applications_list.png"
+      ]
+    },
+    {
+      "url": "127.0.0.1:3000/?info=processed_application_instance",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #processed-applications",
+        "wait for element .govuk-heading-xl to be visible",
+        "click element td > a",
+        "wait for element .govuk-details__summary-text to be visible",
+        "screen capture pa11y/screenshots/manager/processed_application_instance.png"
+      ]
+    },
+    {
+      "url": "127.0.0.1:3000/?info=deleting_application",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #processed-applications",
+        "wait for element .govuk-heading-xl to be visible",
+        "click element td > a",
+        "wait for element .govuk-details__summary-text to be visible",
+        "click element .govuk-details__summary-text",
+        "set field #application_deleted_reason to test",
+        "click element .govuk-button",
+        "wait for element .govuk-error-summary to be visible",
+        "screen capture pa11y/screenshots/manager/deleting_application.png"
+      ]
+    },
+    {
+      "url": "127.0.0.1:3000/?info=deleted_application_instance",
+      "actions": [
+        "wait for element #deleted-applications to be visible",
+        "click element #deleted-applications",
+        "wait for element .govuk-heading-xl to be visible",
+        "click element td > a",
+        "wait for element #result to be visible",
+        "screen capture pa11y/screenshots/manager/deleted_application_instance.png"
+      ]
+    },
+    {
+      "url": "127.0.0.1:3000/?info=paper_app_part_payment_to_completion",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #start-now",
+        "set field #application_title to Mr",
+        "set field #application_first_name to Part",
+        "set field #application_last_name to Payment",
+        "set field #application_day_date_of_birth to 01",
+        "set field #application_month_date_of_birth to 01",
+        "set field #application_year_date_of_birth to 1980",
+        "set field #application_ni_number to AB123456C",
+        "check field #application_married_false",
+        "click element .govuk-button",
+        "set field #application_fee to 111",
+        "check field #application_jurisdiction_id_1",
+        "set field #application_day_date_received to 01",
+        "set field #application_month_date_received to 10",
+        "set field #application_year_date_received to 2020",
+        "set field #application_form_name to C100",
+        "click element .govuk-button",
+        "check field #application_min_threshold_exceeded_false",
+        "click element .govuk-button",
+        "check field #application_benefits_false",
+        "click element .govuk-button",
+        "check field #application_dependents_false",
+        "set field #application_income to 1110",
+        "click element .govuk-button",
+        "wait for element .govuk-button to be visible",
+        "click element .govuk-button",
+        "wait for element #result to be visible",
+        "screen capture pa11y/screenshots/manager/paper_app_part_payment_to_completion.png"
+      ]
+    },
+    {
+      "url": "127.0.0.1:3000/?info=part_payment_app_waiting_for_evidence_result",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element td > a",
+        "wait for element #result to be visible",
+        "click element .govuk-button.util_mb-medium",
+        "wait for element .govuk-heading-xl to be visible",
+        "check field #evidence_correct_true",
+        "click element .govuk-button",
+        "wait for element #evidence_income to be visible",
+        "set field #evidence_income to 1110",
+        "click element .govuk-button",
+        "wait for element #result to be visible",
+        "screen capture pa11y/screenshots/manager/part_payment_app_waiting_for_evidence_result.png"
+      ]
+    },
+    {
+      "url": "127.0.0.1:3000/?info=part_payment_app_waiting_for_evidence_complete_processing",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element td > a",
+        "wait for element #result to be visible",
+        "click element .govuk-button.util_mb-medium",
+        "wait for element .govuk-heading-xl to be visible",
+        "click element .govuk-button",
+        "wait for element #evidence_income to be visible",
+        "click element .govuk-button",
+        "wait for element #result to be visible",
+        "click element .govuk-button",
+        "wait for element #result to be visible",
+        "click element .govuk-button.primary.large",
+        "wait for element .govuk-panel.govuk-panel--confirmation to be visible",
+        "screen capture pa11y/screenshots/manager/part_payment_app_waiting_for_evidence_complete_processing.png"
+      ]
+    },
+    {
+      "url": "127.0.0.1:3000/?info=waiting_for_part_payment_accuracy",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #waiting-for-part-payment",
+        "wait for .govuk-heading-m.heading-icon.util_mt-medium.util_mb-0.heading-icon-part_payment to be visible",
+        "click element td > a",
+        "wait for element .govuk-heading-xl to be visible",
+        "click element .govuk-button.util_mb-medium",
+        "wait for element .govuk-heading-xl to be visible",
+        "screen capture pa11y/screenshots/manager/waiting_for_part_payment_accuracy.png"
+      ]
+    },
+    {
+      "url": "127.0.0.1:3000/?info=waiting_for_part_payment_summary",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #waiting-for-part-payment",
+        "wait for .govuk-heading-m.heading-icon.util_mt-medium.util_mb-0.heading-icon-part_payment to be visible",
+        "click element td > a",
+        "wait for element .govuk-heading-xl to be visible",
+        "click element .govuk-button.util_mb-medium",
+        "wait for element .govuk-heading-xl to be visible",
+        "check field #part_payment_correct_true",
+        "click element .govuk-button",
+        "wait for element #result to be visible",
+        "screen capture pa11y/screenshots/manager/waiting_for_part_payment_summary.png"
+      ]
+    },
+    {
+      "url": "127.0.0.1:3000/?info=waiting_for_part_payment_confirmation",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #waiting-for-part-payment",
+        "wait for .govuk-heading-m.heading-icon.util_mt-medium.util_mb-0.heading-icon-part_payment to be visible",
+        "click element td > a",
+        "wait for element .govuk-heading-xl to be visible",
+        "click element .govuk-button.util_mb-medium",
+        "wait for element .govuk-heading-xl to be visible",
+        "check field #part_payment_correct_true",
+        "click element .govuk-button",
+        "wait for element #result to be visible",
+        "click element .govuk-button.primary.large",
+        "wait for element .govuk-panel.govuk-panel--confirmation to be visible",
+        "screen capture pa11y/screenshots/manager/waiting_for_part_payment_confirmation.png"
+      ]
+    },
+    {
+      "url": "127.0.0.1:3000/?info=paper_app_not_eligible_to_completion",
+      "actions": [
+        "wait for element #start-now to be visible",
+        "click element #start-now",
+        "set field #application_title to Mr",
+        "set field #application_first_name to Not",
+        "set field #application_last_name to Eligible",
+        "set field #application_day_date_of_birth to 01",
+        "set field #application_month_date_of_birth to 01",
+        "set field #application_year_date_of_birth to 1980",
+        "set field #application_ni_number to AB123456C",
+        "check field #application_married_false",
+        "click element .govuk-button",
+        "set field #application_fee to 111",
+        "check field #application_jurisdiction_id_1",
+        "set field #application_day_date_received to 01",
+        "set field #application_month_date_received to 10",
+        "set field #application_year_date_received to 2020",
+        "set field #application_form_name to C100",
+        "click element .govuk-button",
+        "check field #application_min_threshold_exceeded_true",
+        "set field #application_amount to 100000",
+        "click element .govuk-button",
+        "wait for element .govuk-button to be visible",
+        "click element .govuk-button",
+        "wait for element #result to be visible",
+        "screen capture pa11y/screenshots/manager/paper_app_not_eligible_to_completion.png"
       ]
     }
   ]
 }
-
-


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RST-2875

### Change description ###

- Added a few IDs to elements to allow for easy navigation between pages in pa11y testing.
- Updated pa11y tests so that, when logged in as Manager, pages can be accessed using CSS selectors / Actions rather than URLs. This should hopefully enable QAs with different databases to run the pa11y tests.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
