### PR TITLE
RST-3119 bundler update with new ruby docker image source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM employmenttribunal.azurecr.io/ruby-nodejs-onbuild:2.6.6
+FROM phusion/passenger-ruby26
 
 # Adding argument support for ping.json
 ARG APPVERSION=unknown

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -621,4 +621,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   1.17.3
+   2.2.8

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ jobs:
       postgres: postgres
     variables:
       rubyVersion: '= 2.6.6'
-      bundlerVersion: '1.17.3'
+      bundlerVersion: '2.2.8'
       aptDependencies: 'qtbase5-dev xvfb libqtwebkit-dev postgresql-client libpq-dev'
 
     steps:


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RST-3119