### PR TITLE
RST-3801 Removed Covid 19 Guidance in See the guides page.

### DIFF
--- a/app/views/guide/index.html.slim
+++ b/app/views/guide/index.html.slim
@@ -28,11 +28,6 @@ p.govuk-body-l How to process an application, deal with evidence checks, part-pa
 
 .govuk-grid-row
   .govuk-grid-column-one-quarter.guide-cols
-    = link_to covid19_guidance_url
-      span COVID 19 guidance
-      = image_tag("icon-guidance.png", alt: 'Guidance for help with fees processing during COVID19')
-
-  .govuk-grid-column-one-quarter.guide-cols
     = link_to staff_guidance_url
       span Staff guidance
       = image_tag("icon-guidance.png", alt: 'Staff guidance guide icon')
@@ -47,12 +42,12 @@ p.govuk-body-l How to process an application, deal with evidence checks, part-pa
       span Evidence checks
       = image_tag("icon-evidence.png", alt: 'Evidence checks guide icon')
 
-.govuk-grid-row
   .govuk-grid-column-one-quarter.guide-cols
     = link_to guide_part_payments_path
       span Part-payments
       = image_tag("icon-part-fee.png", alt: 'Part-payments guide icon')
 
+.govuk-grid-row
   .govuk-grid-column-one-quarter.guide-cols
     = link_to guide_appeals_path
       span Appeals

--- a/features/staff_guides.feature
+++ b/features/staff_guides.feature
@@ -28,10 +28,6 @@ Feature: Staff guides
       And I am signed in on the guide page
       Then I can view key control checks guide
 
-    Scenario: COVID 19 guidance
-      And I am signed in on the guide page
-      Then I can view the COVID 19 guidance
-
     Scenario: Staff guidance
       And I am signed in on the guide page
       Then I can view staff guidance

--- a/features/step_definitions/staff_guides_steps.rb
+++ b/features/step_definitions/staff_guides_steps.rb
@@ -26,10 +26,6 @@ When("I can view staff guidance") do
   expect(guide_page.content.staff_guidance['href']).to end_with '/documents/2017/10/help-with-fees-policy-guide.pdf'
 end
 
-When("I can view the COVID 19 guidance") do
-  expect(guide_page.content.covid_guidance['href']).to end_with '/documents/2020/04/covid-19-guidance-for-help-with-fees-process.pdf'
-end
-
 When("I click on process application") do
   guide_page.content.process_application.click
 end

--- a/features/support/page_objects/guide_page.rb
+++ b/features/support/page_objects/guide_page.rb
@@ -6,7 +6,6 @@ class GuidePage < BasePage
     element :how_to_guide, 'a', text: 'How to Guide'
     element :training_course, 'a', text: 'HwF Training Course'
     element :key_control_checks, 'a', text: 'Key Control Checks'
-    element :covid_guidance, 'a', text: 'COVID 19 guidance'
     element :staff_guidance, 'a', text: 'Staff guidance'
     element :process_application, 'a', text: 'Process application'
     element :evidence_checks, 'a', text: 'Evidence checks'


### PR DESCRIPTION
Covid 19 Guidance link has been removed from the page See the guides.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
