### PR TITLE
RST-6785 - update rexml to 3.3.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -520,7 +520,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.3.1)
+    rexml (3.3.2)
       strscan
     rotp (6.3.0)
     rouge (4.3.0)


### PR DESCRIPTION
Name: rexml
Version: 3.3.1
Advisory: CVE-2024-39908
Criticality: Unknown
URL: https://github.com/ruby/rexml/security/advisories/GHSA-4xqq-m2hx-25v8
Title: DoS in REXML
Solution: upgrade to '>= 3.3.2'