### PR TITLE
RST-6802 Add Missing Letter to Invalid Evidence Confirmation page

### DIFF
--- a/app/helpers/result_helper.rb
+++ b/app/helpers/result_helper.rb
@@ -24,6 +24,12 @@ module ResultHelper
     !checks.last.benefits_valid?
   end
 
+  def display_evidence_failed_letter?(application)
+    checks = application.evidence_check
+    return false if checks.blank?
+    checks.incorrect_reason_category.present? && checks.correct == false
+  end
+
   def income_value(application)
     return currency_format(application.evidence_check.income) if application.evidence_check&.income&.positive?
 

--- a/app/views/applications/process/confirmation/index.html.slim
+++ b/app/views/applications/process/confirmation/index.html.slim
@@ -107,6 +107,16 @@
         p.govuk-body Write to the applicant and send back all the documents
         p: strong = link_to 'See the guides', guide_path, target: 'blank'
 
+        .confirmation-letter
+          = t('new_letters.evidence.evidence_incorrect_html',
+                  reference: @application.reference,
+                  full_name: @application.applicant.full_name,
+                  legal_rep: @confirm.representative_full_name,
+                  greeting: greeting_condition(@confirm, @application),
+                  user_name: current_user.name,
+                  expiry_date: @confirm.expires_at,
+                  amount_to_pay: currency_format(@application.detail.fee))
+
 
 
 

--- a/app/views/applications/process/confirmation/index.html.slim
+++ b/app/views/applications/process/confirmation/index.html.slim
@@ -83,7 +83,6 @@
               income_total: income_value(@application),
               expiry_date: @confirm.expires_at)
 
-
       -elsif display_benefit_failed_letter?(@application)
         p.govuk-body Write the reference number on the top right corner of the paper form.
         p.govuk-body Write to the applicant using the letter on this page.
@@ -101,7 +100,7 @@
               amount_to_pay: currency_format(@application.detail.fee),
               date_for_part_payment: @confirm.expires_at)
 
-      -else
+      -elsif display_evidence_failed_letter?(@application)
         p.govuk-body Write the reference number on the top right corner of the paper form
         p.govuk-body Copy the reference number into the case management system
         p.govuk-body Write to the applicant and send back all the documents
@@ -116,6 +115,12 @@
                   user_name: current_user.name,
                   expiry_date: @confirm.expires_at,
                   amount_to_pay: currency_format(@application.detail.fee))
+
+      -else
+        p.govuk-body Write the reference number on the top right corner of the paper form
+        p.govuk-body Copy the reference number into the case management system
+        p.govuk-body Write to the applicant and send back all the documents
+        p: strong = link_to 'See the guides', guide_path, target: 'blank'
 
 
 

--- a/config/locales/new_letters_en.yml
+++ b/config/locales/new_letters_en.yml
@@ -199,7 +199,7 @@ en-GB:
           <li>Your savings are too high.</li>
         </ul>
         <p>Unfortunately, this means that the application for help with fees is unsuccessful. </p>
-        <p>You have to pay the fee of £%{amount_to_pay}. You need to pay this by %{expiry_date}.</p>
+        <p>You have to pay the fee of %{amount_to_pay}. You need to pay this by %{expiry_date}.</p>
         <p>This may have an impact on the original case or claim related to this application.</p>
         <h3 class='govuk-heading-m'>How to pay</h3>
         <p>You can pay by:</p>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RST-6802

When a user has to check evidence for an application and reject the evidence, a letter of non correct-representation should be shown but it wasn't.