### PR TITLE
Revert "RST-7098 Updated GovUK Frontend to 5.8.0"

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,7 +18,7 @@ $govuk-new-typography-scale: true;
 $govuk-fonts-path: 'govuk-frontend/dist/govuk/assets/fonts/';
 $govuk-images-path: 'govuk-frontend/dist/govuk/assets/images/';
 
-@import "govuk-frontend/dist/govuk/index";
+@import "govuk-frontend/dist/govuk/all";
 @import "accessible-autocomplete/dist/accessible-autocomplete.min";
 
 /*local*/
@@ -30,6 +30,7 @@ $govuk-images-path: 'govuk-frontend/dist/govuk/assets/images/';
 @import 'local/panels';
 @import 'local/banners';
 @import 'local/dwp-tags';
+
 
 // @import 'local/phase-banner';
 

--- a/charts/help-with-fees-staffapp/Chart.yaml
+++ b/charts/help-with-fees-staffapp/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: '1.0'
 description: A Helm chart for hwf-staffapp App
 name: help-with-fees-staffapp
 home: https://github.com/hmcts/hwf-staffapp
-version: 0.0.72
+version: 0.0.71
 dependencies:
   - name: base
     version: 1.3.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "accessible-autocomplete": "^3.0.0",
-        "govuk-frontend": "^5.8.0"
+        "govuk-frontend": "^5.7.1"
       },
       "engines": {
         "node": ">=0.18.x"
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.8.0.tgz",
-      "integrity": "sha512-6l3f/YhDUCWjpmSW3CL95Hg8B+ZLzTf2WYo25ZtCs2Lb8UIzxxxFI8LxG7Ey/z04UuPhUunqFhTwSkQyJ69XbQ==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.7.1.tgz",
+      "integrity": "sha512-jF1cq5rn57kxZmJRprUZhTQ31zaBBK4b5AyeJaPX3Yhg22lk90Mx/dQLvOk/ycV3wM7e0y+s4IPvb2fFaPlCGg==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "engineStrict": true,
   "dependencies": {
     "accessible-autocomplete": "^3.0.0",
-    "govuk-frontend": "^5.8.0"
+    "govuk-frontend": "^5.7.1"
   },
   "description": "[![Code Climate](https://codeclimate.com/github/ministryofjustice/fr-staffapp/badges/gpa.svg)](https://codeclimate.com/github/ministryofjustice/fr-staffapp) [![Test Coverage](https://codeclimate.com/github/ministryofjustice/fr-staffapp/badges/coverage.svg)](https://codeclimate.com/github/ministryofjustice/fr-staffapp/coverage?sort=covered_percent&sort_direction=asc) [![Build Status](https://travis-ci.org/ministryofjustice/fr-staffapp.svg?branch=master)](https://travis-ci.org/ministryofjustice/fr-staffapp) [![Dependency Status](https://gemnasium.com/badges/github.com/ministryofjustice/fr-staffapp.svg)](https://gemnasium.com/github.com/ministryofjustice/fr-staffapp)",
   "bugs": {


### PR DESCRIPTION
Reverts hmcts/hwf-staffapp#1981
There is an issue with rendering https://staff.helpwithcourtfees.service.gov.uk/assets/govuk-frontend/dist/govuk/govuk-frontend.min-8b6a07624fe1aea82b59a97aa6fbe426ea82d3c47ec993eeb37118ad7b26885d.js 
this happened before, last time we updated govuk frontend. 