### PR TITLE
RST-7126 Removing middleware use of ApplicationInsights

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -46,12 +46,6 @@ module FrStaffapp
     config.i18n.load_path += Rails.root.glob('config/locales/**/*.{rb,yml}')
     config.i18n.default_locale = 'en-GB'
 
-    if ENV['AZURE_APP_INSIGHTS_INSTRUMENTATION_KEY'].present?
-      config.middleware.use(
-        ApplicationInsights::Rack::TrackRequest,
-        ENV['AZURE_APP_INSIGHTS_INSTRUMENTATION_KEY']
-      )
-    end
     config.exceptions_app = routes
 
     config.maintenance_enabled = ENV.fetch('MAINTENANCE_ENABLED', 'false').casecmp('true').zero?


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/RST-7126
https://tools.hmcts.net/jira/browse/RST-7115
Sentry is not reporting correctly the issue because of this I think.