### PR TITLE
Remove text type on input field and keep number type

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -417,7 +417,7 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.7.4)
-    nokogiri (1.18.2)
+    nokogiri (1.18.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     notiffany (0.1.3)

--- a/app/views/shared/savings/_amount.slim
+++ b/app/views/shared/savings/_amount.slim
@@ -10,4 +10,4 @@
 
   .field-wrapper
     span.prefix £
-    = f.text_field :amount, { class: 'govuk-input', type: "text", value: amount_value(@form.amount), type: 'number' }
+    = f.text_field :amount, { class: 'govuk-input', value: amount_value(@form.amount), type: 'number' }


### PR DESCRIPTION
There was duplicate types declared on an input field. Removed the 'text' type and kept the 'number' type.
