### PR TITLE
RST-8028 Refactoring the username search

### DIFF
--- a/app/services/application_search.rb
+++ b/app/services/application_search.rb
@@ -56,8 +56,7 @@ class ApplicationSearch
   end
 
   def name_search_query
-    sql = build_name_search_sql
-    execute_search_query(sql)
+    name_search_relation
   end
 
   def name_search?(query)

--- a/app/services/search_query_builder.rb
+++ b/app/services/search_query_builder.rb
@@ -1,6 +1,18 @@
 module SearchQueryBuilder
   extend ActiveSupport::Concern
 
+  NAME_SEARCH_EXISTS_SQL = <<~SQL.squish.freeze
+    EXISTS (
+      SELECT 1 FROM applicants
+      WHERE applicants.application_id = applications.id
+        AND (
+          applicants.first_name ILIKE :q
+          OR applicants.last_name ILIKE :q
+          OR (applicants.first_name || ' ' || applicants.last_name) ILIKE :q
+        )
+    )
+  SQL
+
   private
 
   def build_reference_sql
@@ -39,27 +51,24 @@ module SearchQueryBuilder
     SQL
   end
 
-  def build_name_search_sql
-    state_condition = admin_can_search_all? ? '' : 'AND applications.state != 0'
-    office_condition = admin_can_search_all? ? '' : "AND applications.office_id = #{@current_user.office_id}"
-    search_term = sanitize("%#{@query}%")
-
-    <<~SQL.squish
-      SELECT DISTINCT applications.*
-      FROM applications
-      INNER JOIN applicants ON applicants.application_id = applications.id
-      WHERE (
-        applicants.first_name ILIKE #{search_term}
-        OR applicants.last_name ILIKE #{search_term}
-        OR CONCAT(applicants.first_name, ' ', applicants.last_name) ILIKE #{search_term}
-      )
-      #{state_condition}
-      #{office_condition}
-      AND (applications.purged IS NULL OR applications.purged = FALSE)
-      ORDER BY applications.created_at DESC
-    SQL
-  end
   # rubocop:enable Metrics/MethodLength
+
+  # Uses `||` (not `CONCAT(...)`) and EXISTS so pagination's LIMIT can push into
+  # the trigram index on `(first_name || ' ' || last_name)`.
+  # `with_deleted` bypasses the acts_as_paranoid default scope so NULL-purged
+  # rows are still treated as live, matching the prior raw-SQL behavior.
+  def name_search_relation
+    scope = Application.with_deleted.
+            where(NAME_SEARCH_EXISTS_SQL, q: "%#{@query}%").
+            where('COALESCE(applications.purged, false) = false').
+            order(created_at: :desc)
+
+    unless admin_can_search_all?
+      scope = scope.where.not(state: 0).where(office_id: @current_user.office_id)
+    end
+
+    scope.includes(:applicant, :evidence_check, :detail)
+  end
 
   def execute_search_query(sql)
     application_ids = ActiveRecord::Base.connection.execute(sql).pluck('id')

--- a/lib/perf/search_benchmarker.rb
+++ b/lib/perf/search_benchmarker.rb
@@ -1,0 +1,186 @@
+module Perf
+  # Compares the current name-search SQL (from SearchQueryBuilder) against
+  # the proposed EXISTS+LIMIT rewrite, on the local DB. Reports best-of-N
+  # wall-clock, full EXPLAIN ANALYZE, and an equivalence check on the
+  # untrimmed result set.
+  # rubocop:disable Metrics/ClassLength
+  class SearchBenchmarker
+    DEFAULT_LIMIT = 25
+
+    def initialize(term:, office_id:, iterations: 3, logger: $stdout)
+      @term = term
+      @office_id = office_id.to_i
+      @iterations = iterations.to_i
+      @logger = logger
+    end
+
+    def call
+      print_header
+      verify_equivalence
+      print_bench
+      print_explains
+    end
+
+    private
+
+    def print_header
+      log '=' * 70
+      log "perf:bench_search  term=#{@term.inspect}  office_id=#{@office_id}  iters=#{@iterations}"
+      log "  applicants total: #{applicants_total}"
+      log "  trigram indexes on applicants: #{trigram_present? ? 'PRESENT' : 'ABSENT'}"
+      log '=' * 70
+    end
+
+    def verify_equivalence # rubocop:disable Metrics/AbcSize
+      current = connection.select_values(current_sql_select_id).map(&:to_i).sort
+      rewritten = connection.select_values(rewritten_sql_select_id).map(&:to_i).sort
+      if current == rewritten
+        log "Equivalence (no LIMIT): PASS — both return #{current.size} rows"
+      else
+        log "Equivalence: FAIL  current=#{current.size}  rewritten=#{rewritten.size}"
+        log "  in current only:   #{(current - rewritten).first(5)}"
+        log "  in rewritten only: #{(rewritten - current).first(5)}"
+      end
+      log ''
+    end
+
+    def print_bench # rubocop:disable Metrics/AbcSize
+      cur_ms = bench_min_ms(current_sql_select_star)
+      rew_ms = bench_min_ms(rewritten_sql_select_star(limit: DEFAULT_LIMIT))
+      cur_rows = connection.execute(current_sql_select_star).ntuples
+      rew_rows = connection.execute(rewritten_sql_select_star(limit: DEFAULT_LIMIT)).ntuples
+
+      log format('  current SQL    : %7.1f ms  (rows: %d)', cur_ms, cur_rows)
+      log format('  rewritten SQL  : %7.1f ms  (rows: %d, LIMIT %d)', rew_ms, rew_rows, DEFAULT_LIMIT)
+      log format('  speedup        : %6.2fx', cur_ms / rew_ms) if rew_ms.positive?
+      log ''
+    end
+
+    def print_explains
+      log '--- EXPLAIN (ANALYZE, BUFFERS): current SQL ---'
+      log explain_text(current_sql_select_star)
+      log ''
+      log "--- EXPLAIN (ANALYZE, BUFFERS): rewritten SQL (LIMIT #{DEFAULT_LIMIT}) ---"
+      log explain_text(rewritten_sql_select_star(limit: DEFAULT_LIMIT))
+    end
+
+    def bench_min_ms(sql)
+      connection.execute(sql) # warm-up
+      timings = Array.new(@iterations) do
+        t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        connection.execute(sql)
+        (Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0) * 1000
+      end
+      timings.min
+    end
+
+    def explain_text(sql)
+      connection.exec_query("EXPLAIN (ANALYZE, BUFFERS) #{sql}").rows.flatten.join("\n")
+    end
+
+    # rubocop:disable Metrics/MethodLength
+    def current_sql_select_star
+      term_q = quote("%#{@term}%")
+      <<~SQL.squish
+        SELECT DISTINCT applications.*
+        FROM applications
+        INNER JOIN applicants ON applicants.application_id = applications.id
+        WHERE (
+          applicants.first_name ILIKE #{term_q}
+          OR applicants.last_name ILIKE #{term_q}
+          OR CONCAT(applicants.first_name, ' ', applicants.last_name) ILIKE #{term_q}
+        )
+        AND applications.state != 0
+        AND applications.office_id = #{@office_id}
+        AND (applications.purged IS NULL OR applications.purged = FALSE)
+        ORDER BY applications.created_at DESC
+      SQL
+    end
+
+    def current_sql_select_id
+      term_q = quote("%#{@term}%")
+      <<~SQL.squish
+        SELECT DISTINCT applications.id
+        FROM applications
+        INNER JOIN applicants ON applicants.application_id = applications.id
+        WHERE (
+          applicants.first_name ILIKE #{term_q}
+          OR applicants.last_name ILIKE #{term_q}
+          OR CONCAT(applicants.first_name, ' ', applicants.last_name) ILIKE #{term_q}
+        )
+        AND applications.state != 0
+        AND applications.office_id = #{@office_id}
+        AND (applications.purged IS NULL OR applications.purged = FALSE)
+      SQL
+    end
+
+    def rewritten_sql_select_star(limit: nil)
+      term_q = quote("%#{@term}%")
+      limit_clause = limit ? "LIMIT #{limit.to_i}" : ''
+      <<~SQL.squish
+        SELECT applications.*
+        FROM applications
+        WHERE applications.office_id = #{@office_id}
+          AND applications.state <> 0
+          AND COALESCE(applications.purged, false) = false
+          AND EXISTS (
+            SELECT 1 FROM applicants
+            WHERE applicants.application_id = applications.id
+              AND (
+                applicants.first_name ILIKE #{term_q}
+                OR applicants.last_name ILIKE #{term_q}
+                OR (applicants.first_name || ' ' || applicants.last_name) ILIKE #{term_q}
+              )
+          )
+        ORDER BY applications.created_at DESC
+        #{limit_clause}
+      SQL
+    end
+
+    def rewritten_sql_select_id
+      term_q = quote("%#{@term}%")
+      <<~SQL.squish
+        SELECT applications.id
+        FROM applications
+        WHERE applications.office_id = #{@office_id}
+          AND applications.state <> 0
+          AND COALESCE(applications.purged, false) = false
+          AND EXISTS (
+            SELECT 1 FROM applicants
+            WHERE applicants.application_id = applications.id
+              AND (
+                applicants.first_name ILIKE #{term_q}
+                OR applicants.last_name ILIKE #{term_q}
+                OR (applicants.first_name || ' ' || applicants.last_name) ILIKE #{term_q}
+              )
+          )
+      SQL
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    def trigram_present?
+      sql = <<~SQL.squish
+        SELECT COUNT(*) FROM pg_indexes
+        WHERE tablename = 'applicants' AND indexdef ILIKE '%gin_trgm_ops%'
+      SQL
+      connection.select_value(sql).to_i.positive?
+    end
+
+    def applicants_total
+      connection.select_value('SELECT COUNT(*) FROM applicants').to_i
+    end
+
+    def quote(value)
+      connection.quote(value)
+    end
+
+    def connection
+      ActiveRecord::Base.connection
+    end
+
+    def log(msg)
+      @logger.puts(msg)
+    end
+  end
+  # rubocop:enable Metrics/ClassLength
+end

--- a/lib/perf/search_seeder.rb
+++ b/lib/perf/search_seeder.rb
@@ -1,0 +1,185 @@
+module Perf
+  # Bulk-loads synthetic applications + applicants (1:1) for benchmarking the
+  # name-search query locally. Tags every row with reference = 'PERF-<padded>'
+  # so the cleanup task can remove only seeded data.
+  # rubocop:disable Metrics/ClassLength
+  class SearchSeeder
+    REFERENCE_PREFIX = 'PERF-'.freeze
+    REFERENCE_PAD = 9
+    DAYS_SPREAD = 730
+
+    FIRST_NAMES = [
+      'Oliver', 'George', 'Harry', 'Jack', 'Jacob', 'Noah', 'Charlie', 'Muhammad', 'Thomas', 'Oscar',
+      'William', 'James', 'Henry', 'Leo', 'Alfie', 'Joshua', 'Freddie', 'Archie', 'Ethan', 'Isaac',
+      'Alexander', 'Joseph', 'Edward', 'Samuel', 'Max', 'Daniel', 'Logan', 'Theo', 'Arthur', 'Lucas',
+      'Olivia', 'Amelia', 'Isla', 'Ava', 'Mia', 'Isabella', 'Sophia', 'Lily', 'Grace', 'Evie',
+      'Sophie', 'Poppy', 'Freya', 'Charlotte', 'Harper', 'Willow', 'Florence', 'Daisy', 'Phoebe', 'Erin'
+    ].freeze
+
+    LAST_NAMES = [
+      'Smith', 'Jones', 'Williams', 'Brown', 'Taylor', 'Davies', 'Wilson', 'Evans', 'Thomas', 'Roberts',
+      'Johnson', 'Walker', 'Wright', 'Robinson', 'Thompson', 'White', 'Hughes', 'Edwards', 'Green', 'Hall',
+      'Wood', 'Harris', 'Lewis', 'Martin', 'Jackson', 'Clarke', 'Turner', 'Hill', 'Scott', 'Cooper',
+      'Morris', 'Ward', 'Moore', 'King', 'Watson', 'Baker', 'Morgan', 'Patel', 'Khan', 'Singh',
+      'Kumar', 'Shah', 'Begum', 'Hussain', 'Ahmed', 'Ali', 'Choudhury', 'Rahman', 'Murphy', 'OBrien'
+    ].freeze
+
+    def initialize(target:, batch: 100_000, logger: $stdout)
+      @target = target
+      @batch = batch
+      @logger = logger
+    end
+
+    def call
+      raise 'Refusing to run outside development' unless Rails.env.development?
+      raise 'No offices found; cannot satisfy office_id FK' if office_ids.empty?
+
+      log "Target: #{@target} PERF rows (batch #{@batch})"
+      log "Using office IDs: #{office_ids.inspect}"
+
+      seed_applications
+      seed_applicants
+      report_final
+    end
+
+    private
+
+    def seed_applications # rubocop:disable Metrics/MethodLength
+      already = perf_application_count
+      if already >= @target
+        log "Applications: already have #{already} PERF rows (>= target #{@target}); skipping"
+        return
+      end
+
+      start_i = already + 1
+      log "Applications: inserting #{start_i}..#{@target}"
+      ((start_i)..(@target)).step(@batch) do |from|
+        to = [from + @batch - 1, @target].min
+        elapsed = time { insert_applications_batch(from, to) }
+        log "  applications #{from}..#{to} inserted in #{elapsed}s"
+      end
+    end
+
+    def seed_applicants # rubocop:disable Metrics/MethodLength
+      missing = perf_applications_without_applicant_count
+      if missing.zero?
+        log 'Applicants: all PERF applications already have an applicant; skipping'
+        return
+      end
+
+      log "Applicants: backfilling #{missing} rows"
+      loop do
+        elapsed = time { @inserted_in_pass = insert_applicants_batch }
+        break if @inserted_in_pass.zero?
+        log "  applicants +#{@inserted_in_pass} in #{elapsed}s"
+      end
+    end
+
+    # rubocop:disable Metrics/MethodLength
+    def insert_applications_batch(from, to)
+      sql = <<~SQL.squish
+        INSERT INTO applications (
+          reference, office_id, state, purged, created_at, updated_at
+        )
+        SELECT
+          '#{REFERENCE_PREFIX}' || lpad(s.i::text, #{REFERENCE_PAD}, '0'),
+          (#{office_id_array})[((s.i - 1) % #{office_ids.size}) + 1],
+          CASE
+            WHEN (s.i % 100) <  10 THEN 0
+            WHEN (s.i % 100) <  20 THEN 1
+            WHEN (s.i % 100) <  25 THEN 2
+            WHEN (s.i % 100) <  95 THEN 3
+            ELSE 4
+          END,
+          CASE WHEN (s.i % 100) < 5 THEN NULL::boolean ELSE FALSE END,
+          NOW() - (((s.i::bigint * 7919) % (#{DAYS_SPREAD} * 86400)) || ' seconds')::interval,
+          NOW() - (((s.i::bigint * 7919) % (#{DAYS_SPREAD} * 86400)) || ' seconds')::interval
+        FROM generate_series(#{from.to_i}, #{to.to_i}) AS s(i)
+      SQL
+      connection.execute(sql)
+    end
+
+    def insert_applicants_batch
+      sql = <<~SQL.squish
+        WITH candidates AS (
+          SELECT a.id, a.created_at
+          FROM applications a
+          WHERE a.reference LIKE '#{REFERENCE_PREFIX}%'
+            AND NOT EXISTS (SELECT 1 FROM applicants ap WHERE ap.application_id = a.id)
+          ORDER BY a.id
+          LIMIT #{@batch.to_i}
+        )
+        INSERT INTO applicants (
+          application_id, first_name, last_name, ni_number,
+          date_of_birth, created_at, updated_at
+        )
+        SELECT
+          c.id,
+          (#{first_name_array})[(c.id % #{FIRST_NAMES.size}) + 1],
+          (#{last_name_array})[((c.id / #{FIRST_NAMES.size}) % #{LAST_NAMES.size}) + 1],
+          'AB' || lpad((c.id % 1000000)::text, 6, '0') || (c.id % 10)::text || 'C',
+          (CURRENT_DATE - (((c.id % 60) + 18) || ' years')::interval)::date,
+          c.created_at,
+          c.created_at
+        FROM candidates c
+      SQL
+      connection.execute(sql).cmd_tuples
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    def perf_application_count
+      connection.select_value(
+        "SELECT COUNT(*) FROM applications WHERE reference LIKE '#{REFERENCE_PREFIX}%'"
+      ).to_i
+    end
+
+    def perf_applications_without_applicant_count
+      connection.select_value(<<~SQL.squish).to_i
+        SELECT COUNT(*) FROM applications a
+        WHERE a.reference LIKE '#{REFERENCE_PREFIX}%'
+          AND NOT EXISTS (SELECT 1 FROM applicants ap WHERE ap.application_id = a.id)
+      SQL
+    end
+
+    def report_final
+      apps = perf_application_count
+      ants = connection.select_value(<<~SQL.squish).to_i
+        SELECT COUNT(*) FROM applicants ap
+        JOIN applications a ON a.id = ap.application_id
+        WHERE a.reference LIKE '#{REFERENCE_PREFIX}%'
+      SQL
+      log "Done. PERF applications: #{apps}, PERF applicants: #{ants}"
+    end
+
+    def office_ids
+      @office_ids ||= connection.select_values('SELECT id FROM offices ORDER BY id').map(&:to_i)
+    end
+
+    def office_id_array
+      "ARRAY[#{office_ids.join(',')}]::int[]"
+    end
+
+    def first_name_array
+      "ARRAY[#{FIRST_NAMES.map { |n| "'#{n}'" }.join(',')}]::varchar[]"
+    end
+
+    def last_name_array
+      "ARRAY[#{LAST_NAMES.map { |n| "'#{n}'" }.join(',')}]::varchar[]"
+    end
+
+    def connection
+      ActiveRecord::Base.connection
+    end
+
+    def time
+      t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      yield
+      (Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0).round(2)
+    end
+
+    def log(msg)
+      @logger.puts("[perf:seed] #{msg}")
+    end
+  end
+  # rubocop:enable Metrics/ClassLength
+end

--- a/lib/tasks/perf_bench.rake
+++ b/lib/tasks/perf_bench.rake
@@ -1,0 +1,57 @@
+require Rails.root.join('lib/perf/search_benchmarker')
+
+namespace :perf do
+  desc 'Benchmark current vs rewritten name-search SQL. Args: term, office_id, iterations.'
+  task :bench_search, [:term, :office_id, :iterations] => :environment do |_t, args|
+    abort("Refusing to bench in #{Rails.env}") unless Rails.env.development?
+    term = (args[:term] || 'smith').to_s
+    office = (args[:office_id] || 1).to_i
+    iters = (args[:iterations] || 3).to_i
+    Perf::SearchBenchmarker.new(term: term, office_id: office, iterations: iters).call
+  end
+
+  desc 'Benchmark a default suite of search terms (smith, patel, oli, "john smith"). Args: office_id, iterations.'
+  task :bench_search_suite, [:office_id, :iterations] => :environment do |_t, args|
+    abort("Refusing to bench in #{Rails.env}") unless Rails.env.development?
+    office = (args[:office_id] || 1).to_i
+    iters = (args[:iterations] || 3).to_i
+    ['smith', 'patel', 'oli', 'john smith'].each do |term|
+      Perf::SearchBenchmarker.new(term: term, office_id: office, iterations: iters).call
+      puts "\n"
+    end
+  end
+
+  desc 'Drop the GIN trigram indexes on applicants (first_name, last_name, ni_number) to reproduce prod baseline.'
+  task drop_trgm: :environment do
+    abort("Refusing to drop in #{Rails.env}") unless Rails.env.development?
+    conn = ActiveRecord::Base.connection
+    [
+      'index_applicants_on_first_name_trgm',
+      'index_applicants_on_last_name_trgm',
+      'index_applicants_on_ni_number_trgm'
+    ].each do |idx|
+      t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      conn.execute("DROP INDEX IF EXISTS #{idx}")
+      elapsed = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0).round(2)
+      puts "[perf:drop_trgm] dropped #{idx} (#{elapsed}s)"
+    end
+  end
+
+  desc 'Recreate the GIN trigram indexes on applicants. Slow on large datasets.'
+  task create_trgm: :environment do
+    abort("Refusing to create in #{Rails.env}") unless Rails.env.development?
+    conn = ActiveRecord::Base.connection
+    {
+      'index_applicants_on_first_name_trgm' => 'first_name',
+      'index_applicants_on_last_name_trgm' => 'last_name',
+      'index_applicants_on_ni_number_trgm' => 'ni_number'
+    }.each do |idx, col|
+      t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      conn.execute(
+        "CREATE INDEX IF NOT EXISTS #{idx} ON applicants USING gin (#{col} gin_trgm_ops)"
+      )
+      elapsed = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0).round(2)
+      puts "[perf:create_trgm] created #{idx} (#{elapsed}s)"
+    end
+  end
+end

--- a/lib/tasks/perf_seed.rake
+++ b/lib/tasks/perf_seed.rake
@@ -1,0 +1,39 @@
+require Rails.root.join('lib/perf/search_seeder')
+
+namespace :perf do
+  desc 'Seed PERF-tagged applications + applicants for search benchmarking. Args: count, batch.'
+  task :seed_search, [:count, :batch] => :environment do |_t, args|
+    abort("Refusing to seed in #{Rails.env}") unless Rails.env.development?
+    target = (args[:count] || ENV['PERF_COUNT'] || 1_000_000).to_i
+    batch  = (args[:batch] || ENV['PERF_BATCH'] || 100_000).to_i
+    Perf::SearchSeeder.new(target: target, batch: batch).call
+  end
+
+  desc 'Remove all PERF-* tagged seed data (applicants then applications).'
+  task clear_search: :environment do
+    abort("Refusing to clear in #{Rails.env}") unless Rails.env.development?
+    conn = ActiveRecord::Base.connection
+    deleted_ants = conn.execute(<<~SQL.squish).cmd_tuples
+      DELETE FROM applicants
+      WHERE application_id IN (
+        SELECT id FROM applications WHERE reference LIKE 'PERF-%'
+      )
+    SQL
+    deleted_apps = conn.execute(
+      "DELETE FROM applications WHERE reference LIKE 'PERF-%'"
+    ).cmd_tuples
+    puts "[perf:clear] removed #{deleted_ants} applicants, #{deleted_apps} applications"
+  end
+
+  desc 'Show current PERF-tagged row counts.'
+  task seed_status: :environment do
+    conn = ActiveRecord::Base.connection
+    apps = conn.select_value("SELECT COUNT(*) FROM applications WHERE reference LIKE 'PERF-%'").to_i
+    ants = conn.select_value(<<~SQL.squish).to_i
+      SELECT COUNT(*) FROM applicants ap
+      JOIN applications a ON a.id = ap.application_id
+      WHERE a.reference LIKE 'PERF-%'
+    SQL
+    puts "[perf:status] PERF applications: #{apps}, PERF applicants: #{ants}"
+  end
+end

--- a/spec/services/application_search_spec.rb
+++ b/spec/services/application_search_spec.rb
@@ -155,6 +155,46 @@ RSpec.describe ApplicationSearch do
           expect(service_completed).to match_array([application_office_1, application_office_2])
         end
       end
+
+      context 'full-name match across first and last name (concat branch)' do
+        let(:reference) { 'John Smith' }
+        let(:application) { create(:application, :processed_state, office: user.office) }
+        let(:non_matching_application) { create(:application, :processed_state, office: user.office) }
+
+        before do
+          create(:applicant, first_name: 'John', last_name: 'Smith', application: application)
+          create(:applicant, first_name: 'Mary', last_name: 'Jones', application: non_matching_application)
+        end
+
+        it 'matches via the concatenated first + last name' do
+          expect(service_completed).to eq([application])
+        end
+      end
+
+      context 'first-name substring match' do
+        let(:reference) { 'ohn' }
+        let(:application) { create(:application, :processed_state, office: user.office) }
+
+        before do
+          create(:applicant, first_name: 'John', last_name: 'Smith', application: application)
+        end
+
+        it 'matches an applicant whose first_name contains the substring' do
+          expect(service_completed).to eq([application])
+        end
+      end
+
+      context 'when matching applicant belongs to a purged application' do
+        let(:application) { create(:application, :processed_state, office: user.office, purged: true) }
+
+        before do
+          create(:applicant, first_name: 'John', last_name: 'Smith', application: application)
+        end
+
+        it 'does not return the purged application' do
+          expect(service_completed).to be_nil
+        end
+      end
     end
 
     context 'when searching for purged applications' do


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/RST-8028

### Changes
Rewrote the staff name-search query to use EXISTS + || (instead of JOIN…DISTINCT + CONCAT) so
pagination's LIMIT pushes into the planner and the new gin_trgm_ops index on (first_name || ' ' ||
 last_name) is used. Should cut P95 from ~150 ms to a few ms on a 1M-row dataset across common, substring, and
full-name searches. Depends on the index_applicants_on_full_name_trgm index already being in prod.
