### PR TITLE
Test speedup

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,7 @@ GEM
     crack (1.0.1)
       bigdecimal
       rexml
-    crass (1.0.6)
+    crass (1.0.7)
     cssbundling-rails (1.4.3)
       railties (>= 6.0.0)
     csv (3.3.5)
@@ -385,9 +385,6 @@ GEM
       reline (>= 0.6.0)
     pry-rails (0.3.11)
       pry (>= 0.13.0)
-    psych (5.4.0)
-      date
-      stringio
     public_suffix (7.0.5)
     puma (8.0.2)
       nio4r (~> 2.0)
@@ -445,9 +442,14 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rdoc (7.2.0)
+    rbs (4.0.3)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rdoc (8.0.0)
       erb
-      psych (>= 4.0.0)
+      prism (>= 1.6.0)
+      rbs (>= 4.0.0)
       tsort
     readline (0.0.4)
       reline
@@ -526,7 +528,7 @@ GEM
     ruby-vips (2.3.0)
       ffi (~> 1.12)
       logger
-    rubyzip (3.4.0)
+    rubyzip (3.4.1)
     sdoc (2.6.5)
       rdoc (>= 5.0)
     securerandom (0.4.1)
@@ -568,7 +570,6 @@ GEM
       railties (>= 3.1)
       slim (>= 3.0, < 6.0, != 5.0.0)
     stackprof (0.2.28)
-    stringio (3.2.0)
     sys-uname (1.5.1)
       ffi (~> 1.1)
       memoist3 (~> 1.0.0)

--- a/docs/test_performance.md
+++ b/docs/test_performance.md
@@ -1,0 +1,43 @@
+# Test performance metrics (local)
+
+A local way to see what's slow in the test suite so we can measure before/after
+when speeding things up. None of this runs on CI - CI is unchanged.
+
+## See the stats
+
+```
+# Whole suite: slowest examples/groups + which factories cost the most time.
+bundle exec rake test:profile
+
+# Scope it to a folder or file:
+bundle exec rake "test:profile[spec/features]"
+bundle exec rake "test:profile[spec/models/benefit_check_spec.rb]"
+```
+
+This runs RSpec with `--profile 25` and `test-prof`'s FactoryProf. You'll see:
+
+- **Top 25 slowest examples** and **slowest example groups** - which specs to
+  look at first.
+- **`Finished in X seconds`** - the suite/scope total (use this to compare runs).
+- **FactoryProf report** - a table of factories by total time and number of
+  runs. Excessive `create` (vs `build`/`build_stubbed`) and deep factory
+  associations are the usual reason specs are slow.
+
+## Other profilers (optional)
+
+`test-prof` profilers switch on via env var on a normal `rspec` run, e.g.:
+
+```
+EVENT_PROF='sql.active_record' bundle exec rspec spec/features   # time spent in SQL
+```
+
+## Comparing before/after
+
+Note the `Finished in` total and the Top-N slowest lists, make a change, run
+the same scope again, and compare.
+
+## Likely next levers
+
+- **Parallelise RSpec.** `parallel_tests` is already in the Gemfile but the suite
+  runs serially - splitting spec files across cores is the biggest expected win.
+- **Cut factory cost** in the slowest specs (`build_stubbed` / `let_it_be`).

--- a/features/change_user_details.feature
+++ b/features/change_user_details.feature
@@ -10,6 +10,7 @@ Feature: Change user details
     When I click on change details of a user
     Then I can change the user to a user, manager, admin, mi, reader
 
+  @javascript
   Scenario: User profile is saved
     Given I am admin on the staff page
     When I click on change details of a user

--- a/features/find_application.feature
+++ b/features/find_application.feature
@@ -57,6 +57,7 @@ Feature: Find an application
     When I search leaving the input box blank
     Then I get the cannot be blank error message
   
+  @javascript
   Scenario: Pagination
     Given I have more than 20 search results
     Then I see that it is paginated by 20 results per page

--- a/features/notification_banner.feature
+++ b/features/notification_banner.feature
@@ -4,6 +4,7 @@ Feature: Notification banner
     Given I successfully sign in as admin
     And I am on the edit notification page
 
+  @javascript
   Scenario: Add notification banner
     When I add a message
     And I check show on admin homepage
@@ -11,6 +12,7 @@ Feature: Notification banner
     Then I should see your changes have been saved message
     And I should see the notification on my homepage
 
+  @javascript
   Scenario: Remove notification banner
     When I add a message
     And I check show on admin homepage

--- a/features/override.feature
+++ b/features/override.feature
@@ -20,6 +20,7 @@ Feature: Override
     And The application should remain ineligible
     And I should not see a message telling me the application passed by manager's decision
 
+  @javascript
   Scenario: Paper evidence gives reason to override income decision
     Given I have completed an ineligible paper application - income too high
     When I click on Grant help with fees
@@ -36,6 +37,7 @@ Feature: Override
     Then I should see a message telling me the application passed by manager's decision
     And The application should become eligible
 
+  @javascript
   Scenario: Your delivery manager has allowed discretion with this application
     Given I have completed an ineligible paper application - income too high
     When I click on Grant help with fees
@@ -44,6 +46,7 @@ Feature: Override
     Then I should see a message telling me the application passed by manager's decision
     And The application should become eligible
 
+  @javascript
   Scenario: You want to check if the applicant is receiving benefits using the DWP checker
     Given I have completed an ineligible paper application - income too high
     When I click on Grant help with fees

--- a/features/override_results_discretion.feature
+++ b/features/override_results_discretion.feature
@@ -14,6 +14,7 @@ Feature: Override results Discretionary pass
     Then I should see a confirmation letter
     And I should see that the application fails because of income
 
+  @javascript
   Scenario: High income - after granting hwf
     Given I input low savings and no benefits but 5000 income and then complete processing
     When I grant help with fees by choosing delivery manager discretion

--- a/features/savings_investments.feature
+++ b/features/savings_investments.feature
@@ -35,6 +35,7 @@ Feature: Savings and investments page
     When I click on more than £16000
     Then My application gets no remission
 
+  @javascript
   Scenario: I press Next without selecting any radio button
     Given I am on the savings and investments part of the application
     When I click next without selecting a savings and investments option

--- a/features/support/capybara_driver_helper.rb
+++ b/features/support/capybara_driver_helper.rb
@@ -3,8 +3,20 @@ require 'selenium/webdriver'
 Selenium::WebDriver.logger.level = :error
 
 Capybara.configure do |config|
-  driver = ENV['DRIVER']&.to_sym || :cuprite
-  config.default_driver = driver
+  # Default to the in-process rack_test driver (no browser) - it is ~5-13x
+  # faster than driving real Chrome. Scenarios that genuinely need JavaScript
+  # (show/hide sections, execute_script) are tagged @javascript and run under
+  # the cuprite headless-Chrome driver instead (see Capybara.javascript_driver).
+  # Smoke tests run against a remote TEST_URL with no in-process server, so they
+  # need a real browser - keep cuprite for those.
+  config.default_driver =
+    if ENV['DRIVER']
+      ENV['DRIVER'].to_sym
+    elsif ENV['RUN_SMOKE_TESTS'] == 'true'
+      :cuprite
+    else
+      :rack_test
+    end
   config.default_max_wait_time = 10
   config.default_normalize_ws = true
   config.match = :prefer_exact
@@ -74,7 +86,7 @@ Capybara::Screenshot.register_filename_prefix_formatter(:cucumber) do |scenario|
 end
 
 Capybara.always_include_port = true
-Capybara.javascript_driver = Capybara.default_driver
+Capybara.javascript_driver = :cuprite
 
 # Uncomment and set to your test URL to run tests against localhost
 # ENV['TEST_URL'] = 'http://localhost:3000/'

--- a/features/support/rack_test_block_elements.rb
+++ b/features/support/rack_test_block_elements.rb
@@ -1,0 +1,39 @@
+# Capybara's rack_test driver extracts visible text without processing CSS, so
+# it spaces text differently from a real browser (cuprite). Two cases bite the
+# GOV.UK markup and make browser-passing feature specs fail purely on spacing:
+#
+#  1. rack_test only inserts whitespace around a subset of block elements (see
+#     Capybara::RackTest::Node#displayed_text / BLOCK_ELEMENTS). That list omits
+#     dt, dd, li and table cells, so summary-list and table text is run together
+#     ("Full nameJohn" instead of "Full name John").
+#
+#  2. govuk-visually-hidden text (e.g. the label in a "Change" link) is
+#     absolutely positioned, so a browser renders whitespace around it
+#     ("Change Full name"); rack_test ignores CSS and runs it together
+#     ("ChangeFull name").
+#
+# Mirroring both here makes rack_test text match the browser so the same specs
+# pass under both drivers.
+module Capybara
+  module RackTest
+    class Node
+      additional_block_elements = [
+        'dt', 'dd', 'li', 'tr', 'td', 'th', 'thead', 'tbody', 'tfoot', 'caption', 'section', 'article', 'aside', 'header', 'footer', 'nav', 'main', 'figure', 'figcaption'
+      ]
+      extended_block_elements = (BLOCK_ELEMENTS + additional_block_elements).uniq.freeze
+      remove_const(:BLOCK_ELEMENTS)
+      const_set(:BLOCK_ELEMENTS, extended_block_elements)
+
+      module VisuallyHiddenSpacing
+        def displayed_text(check_ancestor: true)
+          text = super
+          return text unless native.element?
+          return text unless native[:class].to_s.split.include?('govuk-visually-hidden')
+
+          "\n#{text}\n"
+        end
+      end
+      prepend VisuallyHiddenSpacing
+    end
+  end
+end

--- a/features/unprocessed_applications_when_dwp_is_down.feature
+++ b/features/unprocessed_applications_when_dwp_is_down.feature
@@ -37,6 +37,7 @@ Feature: Unprocessed applications when DWP is down
     And I complete processing the application
     Then I should be on the result page with the application status set to processed
 
+  @javascript
   Scenario: View an application on the pending list
     Given There is an application pending
     And I am a staff member at the home page
@@ -60,11 +61,13 @@ Feature: Unprocessed applications when DWP is down
     Then I should see 'Not ready to process' in red text
     And the 'Id' should still be selectable as a link
 
+  @javascript
   Scenario: The only applications visible on the list are within an office
     Given There are 2 applications that have been submitted and pending for different offices
     And I am a staff member at the 'Pending benefit applications' page with the DWP checker online
     Then I should only see the application for my office in the pending list
 
+  @javascript
   Scenario: Logged in as an admin after DWP outage and can view pending application
     Given I am logged in as an admin and there is an application pending
     And there is a heading 'Process when DWP is back online'

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -36,4 +36,16 @@ namespace :test do
       raise "Functional tests failed"
     end
   end
+
+  # Local-only deep profiling to find what makes the RSpec suite slow. Combines
+  # RSpec's --profile (slowest examples/groups) with test-prof's FactoryProf
+  # (which factories cost the most time - usually the biggest offender). Pass a
+  # path to scope it, e.g. bundle exec rake test:profile[spec/features]
+  desc 'Profile the RSpec suite locally (slowest examples + factory usage)'
+  task :profile, [:path] => :environment do |_task, args|
+    path = args[:path] || 'spec'
+    ENV['TEST_PROF'] = '1'
+    ENV['FPROF'] = '1'
+    system("bundle exec rspec #{path} --profile 25")
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -27,6 +27,10 @@ require 'webmock/rspec'
 require 'capybara/apparition'
 require 'mock_redis'
 
+# Opt-in performance profiling (off by default, zero impact on normal runs).
+# Enable via `bundle exec rake test:profile` or e.g. FPROF=1 bundle exec rspec.
+require 'test_prof' if ENV['TEST_PROF'] || ENV['FPROF'] || ENV['EVENT_PROF']
+
 
 # Add additional requires below this line. Rails is not loaded until this point!
 


### PR DESCRIPTION
### Change description
To reduce the CI run build, I look at the tests and how we can speed up the runs. There is a significant time saving when we use a rack-based driver for non-Javascript pages in feature tests. 